### PR TITLE
refactor: use iterator's position method to find first index of occurrence

### DIFF
--- a/src/genome.rs
+++ b/src/genome.rs
@@ -10,7 +10,6 @@ use std::str;
 
 use bam_generator::*;
 use coverage_takers::*;
-use genomes_and_contigs::find_first;
 use genomes_and_contigs::GenomesAndContigs;
 use mosdepth_genome_coverage_estimators::*;
 use ReadsMapped;
@@ -787,7 +786,7 @@ pub fn mosdepth_genome_coverage<
 fn extract_genome<'a>(tid: u32, target_names: &'a [&[u8]], split_char: u8) -> &'a [u8] {
     let target_name = target_names[tid as usize];
     trace!("target name {:?}, separator {:?}", target_name, split_char);
-    let offset = find_first(target_name, split_char).unwrap_or_else(|_| panic!("Contig name {} does not contain split symbol, so cannot determine which genome it belongs to",
+    let offset = target_name.iter().position(|&c| c == split_char).unwrap_or_else(|| panic!("Contig name {} does not contain split symbol, so cannot determine which genome it belongs to",
                  str::from_utf8(target_name).unwrap()));
     &target_name[0..offset]
 }

--- a/src/genome_exclusion.rs
+++ b/src/genome_exclusion.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 use std::str;
 
-use genomes_and_contigs::find_first;
 use genomes_and_contigs::GenomesAndContigs;
 
 pub enum GenomeExcluders<'a> {
@@ -53,7 +52,7 @@ impl<'a> GenomeExclusion for SeparatorGenomeExclusionFilter<'a> {
             "contig name {:?}, separator {:?}",
             contig_name, self.split_char
         );
-        let offset = find_first(contig_name, self.split_char).unwrap_or_else(|_| panic!("Contig name {} does not contain split symbol, so cannot determine which genome it belongs to",
+        let offset = contig_name.iter().position(|&c|c == self.split_char).unwrap_or_else(|| panic!("Contig name {} does not contain split symbol, so cannot determine which genome it belongs to",
                      self.split_char));
         let genome = &contig_name[0..offset];
         self.excluded_genomes.contains(genome)

--- a/src/genomes_and_contigs.rs
+++ b/src/genomes_and_contigs.rs
@@ -3,19 +3,6 @@
 use std::collections::HashMap;
 use std::process;
 
-/// Finds the first occurence of element in a slice
-pub fn find_first<T>(slice: &[T], element: T) -> Result<usize, &'static str>
-where
-    T: std::cmp::PartialEq<T>,
-{
-    for (index, el) in slice.iter().enumerate() {
-        if *el == element {
-            return Ok(index);
-        }
-    }
-    Err("Element not found in slice")
-}
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct GenomesAndContigs {
     pub genomes: Vec<String>,
@@ -54,10 +41,9 @@ impl GenomesAndContigs {
     }
 
     pub fn genome_index(&self, genome_name: &String) -> Option<usize> {
-        match find_first(self.genomes.as_slice(), genome_name.to_string()) {
-            Ok(index) => Some(index),
-            Err(_) => None,
-        }
+        self.genomes
+            .iter()
+            .position(|genome| genome.eq(genome_name))
     }
 
     pub fn genome_of_contig(&self, contig_name: &String) -> Option<&String> {


### PR DESCRIPTION
### Changes
- Removes manual implementation of finding first index.
- Replaces all occurrences of `find_first` with the position method of iterators. 

Tests are passing.