### PR TITLE
tests: replace manual file reads with fs::read_to_string

### DIFF
--- a/src/contig.rs
+++ b/src/contig.rs
@@ -307,12 +307,7 @@ mod tests {
                 1,
             );
         }
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-        assert_eq!(expected, str::from_utf8(&buf).unwrap());
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
         reads_mapped_vec
     }
 

--- a/src/coverage_printer.rs
+++ b/src/coverage_printer.rs
@@ -637,15 +637,10 @@ mod tests {
             None,
             None,
         );
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
         assert_eq!(
             "contigName\tcontigLen\ttotalAvgDepth\tstoit1.bam\tstoit1.bam-var\tstoit2.bam\tstoit2.bam-var\n\
              contig1\t1024\t11.1\t1.1\t1.2\t21.1\t21.2\n\
              contig2\t1025\t12.1\t2.1\t2.2\t22.1\t22.2\n",
-             str::from_utf8(&buf).unwrap());
+             std::fs::read_to_string(tf.path()).unwrap());
     }
 }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -959,12 +959,7 @@ mod tests {
                 1,
             );
         }
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-        assert_eq!(expected, str::from_utf8(&buf).unwrap());
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
         res
     }
 
@@ -1003,12 +998,7 @@ mod tests {
                 1,
             );
         }
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-        assert_eq!(expected, str::from_utf8(&buf).unwrap());
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
         res
     }
 
@@ -1043,12 +1033,7 @@ mod tests {
                 1,
             );
         }
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-        assert_eq!(expected, str::from_utf8(&buf).unwrap());
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
         res
     }
 
@@ -1085,12 +1070,7 @@ mod tests {
                 1,
             );
         }
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-        assert_eq!(expected, str::from_utf8(&buf).unwrap());
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
         res
     }
 

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -2369,17 +2369,11 @@ genome6~random_sequence_length_11003	0	0	0
             .is("")
             .unwrap();
 
-        let mut buf = vec![];
-        std::fs::File::open(tf.path())
-            .unwrap()
-            .read_to_end(&mut buf)
-            .unwrap();
-
         assert_eq!(
             "Sample\tContig\tMean\n\
             2seqs.fasta/bad_reads.interleaved.fq\tseq1\t0.899\n\
             2seqs.fasta/bad_reads.interleaved.fq\tseq2\t0\n",
-            str::from_utf8(&buf).unwrap()
+            std::fs::read_to_string(tf.path()).unwrap()
         )
     }
 


### PR DESCRIPTION
Since all the tests read the temporary files as string values, we are better off using the `fs::read_to_string` function for assertions.