### PR TITLE
refactor: pass inexpensive `f32` instead of `&f32`

### DIFF
--- a/src/contig.rs
+++ b/src/contig.rs
@@ -77,7 +77,7 @@ pub fn contig_coverage<R: NamedBamReader, G: NamedBamReaderGenerator<R>, T: Cove
                             std::str::from_utf8(target_names[last_tid as usize]).unwrap(),
                         );
                         for (coverage, estimator) in
-                            coverages.iter().zip(coverage_estimators.iter_mut())
+                            coverages.into_iter().zip(coverage_estimators.iter_mut())
                         {
                             estimator.print_coverage(coverage, coverage_taker);
                         }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -283,7 +283,7 @@ pub fn mosdepth_genome_coverage_with_contig_names<
                         // Print coverage of previous genome
                         debug!("Found coverage {} for genome {}", coverage, genome);
                         if coverage > 0.0 {
-                            coverage_estimator.print_coverage(&coverage, coverage_taker);
+                            coverage_estimator.print_coverage(coverage, coverage_taker);
                         } else {
                             coverage_estimator.print_zero_coverage(
                                 coverage_taker,
@@ -379,7 +379,7 @@ fn print_last_genomes<T: CoverageTaker>(
 
                 // Print coverage of previous genome
                 if coverage > 0.0 {
-                    coverage_estimator.print_coverage(&coverage, coverage_taker);
+                    coverage_estimator.print_coverage(coverage, coverage_taker);
                 } else {
                     coverage_estimator.print_zero_coverage(
                         coverage_taker,

--- a/src/mosdepth_genome_coverage_estimators.rs
+++ b/src/mosdepth_genome_coverage_estimators.rs
@@ -233,7 +233,7 @@ pub trait MosdepthGenomeCoverageEstimator {
 
     fn calculate_coverage(&mut self, unobserved_contig_lengths: &[u64]) -> f32;
 
-    fn print_coverage<T: CoverageTaker>(&self, coverage: &f32, coverage_taker: &mut T);
+    fn print_coverage<T: CoverageTaker>(&self, coverage: f32, coverage_taker: &mut T);
 
     fn print_zero_coverage<T: CoverageTaker>(&self, coverage_taker: &mut T, entry_length: u64);
 
@@ -890,7 +890,7 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
         }
     }
 
-    fn print_coverage<T: CoverageTaker>(&self, coverage: &f32, coverage_taker: &mut T) {
+    fn print_coverage<T: CoverageTaker>(&self, coverage: f32, coverage_taker: &mut T) {
         match self {
             CoverageEstimator::MeanGenomeCoverageEstimator { .. }
             | CoverageEstimator::TrimmedMeanGenomeCoverageEstimator { .. }
@@ -902,7 +902,7 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             | CoverageEstimator::ReferenceLengthCalculator { .. }
             | CoverageEstimator::ReadCountCalculator { .. }
             | CoverageEstimator::ReadsPerBaseCalculator { .. } => {
-                coverage_taker.add_single_coverage(*coverage);
+                coverage_taker.add_single_coverage(coverage);
             }
             CoverageEstimator::PileupCountsGenomeCoverageEstimator { counts, .. } => {
                 debug!("{:?}", counts);


### PR DESCRIPTION
It might be a good idea to pass a float32 by value instead of a reference. The reference (on most systems) will be stored in a 64 bit register. Might as well pass the raw value instead of the indirection.