### PR TITLE
Add option to name cached BAM outputs

### DIFF
--- a/docs/coverm-contig.html
+++ b/docs/coverm-contig.html
@@ -401,6 +401,12 @@ code span.ot { color: #007020; }
 </dl>
 <!-- -->
 <dl>
+<dt><strong>--bam-file-cache-names</strong> <em>FILE</em>...</dt>
+<dd><p>Output BAM files generated during alignment to these files. The order of files should correspond to: single-ended reads (-s), -1/-2, --coupled, --interleaved. [default: not used]</p>
+</dd>
+</dl>
+<!-- -->
+<dl>
 <dt><strong>--discard-unmapped</strong></dt>
 <dd><p>Exclude unmapped reads from cached BAM files. [default: not set]</p>
 </dd>

--- a/docs/coverm-genome.html
+++ b/docs/coverm-genome.html
@@ -582,6 +582,12 @@ code span.ot { color: #007020; }
 </dl>
 <!-- -->
 <dl>
+<dt><strong>--bam-file-cache-names</strong> <em>FILE</em>...</dt>
+<dd><p>Output BAM files generated during alignment to these files. The order of files should correspond to: single-ended reads (-s), -1/-2, --coupled, --interleaved. [default: not used]</p>
+</dd>
+</dl>
+<!-- -->
+<dl>
 <dt><strong>--discard-unmapped</strong></dt>
 <dd><p>Exclude unmapped reads from cached BAM files. [default: not set]</p>
 </dd>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -605,6 +605,13 @@ pub fn contig_full_help() -> Manual {
                 [default: not used]",
                     ),
             )
+            .option(
+                Opt::new("FILE")
+                    .long("--bam-file-cache-names")
+                    .help(
+                        "Output BAM files generated during alignment to these files. The order of files should correspond to: single-ended reads (-s), -1/-2, --coupled, --interleaved. [default: not used]",
+                    ),
+            )
             .flag(
                 Flag::new()
                     .long("--discard-unmapped")
@@ -845,6 +852,13 @@ pub fn genome_full_help() -> Manual {
                 are excluded by alignment thresholding (e.g. --min-read-percent-identity) or \
                 genome-wise thresholding (e.g. --min-covered-fraction). \
                 [default: not used]",
+                    ),
+            )
+            .option(
+                Opt::new("FILE")
+                    .long("--bam-file-cache-names")
+                    .help(
+                        "Output BAM files generated during alignment to these files. The order of files should correspond to: single-ended reads (-s), -1/-2, --coupled, --interleaved. [default: not used]",
                     ),
             )
             .flag(
@@ -1163,7 +1177,20 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                 .arg(
                     Arg::new("bam-file-cache-directory")
                         .long("bam-file-cache-directory")
-                        .conflicts_with("bam-files"),
+                        .conflicts_with("bam-files")
+                        .conflicts_with("bam-file-cache-names"),
+                )
+                .arg(
+                    Arg::new("bam-file-cache-names")
+                        .long("bam-file-cache-names")
+                        .action(clap::ArgAction::Append)
+                        .num_args(1..)
+                        .conflicts_with("bam-files")
+                        .conflicts_with("bam-file-cache-directory"),
+                )
+                .group(
+                    ArgGroup::new("bam-file-cache")
+                        .args(["bam-file-cache-directory", "bam-file-cache-names"]),
                 )
                 .arg(
                     Arg::new("threads")
@@ -1215,7 +1242,7 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                 .arg(
                     Arg::new("discard-unmapped")
                         .long("discard-unmapped")
-                        .requires("bam-file-cache-directory")
+                        .requires("bam-file-cache")
                         .action(clap::ArgAction::SetTrue),
                 )
                 .arg(
@@ -1684,7 +1711,20 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                 .arg(
                     Arg::new("bam-file-cache-directory")
                         .long("bam-file-cache-directory")
-                        .conflicts_with("bam-files"),
+                        .conflicts_with("bam-files")
+                        .conflicts_with("bam-file-cache-names"),
+                )
+                .arg(
+                    Arg::new("bam-file-cache-names")
+                        .long("bam-file-cache-names")
+                        .action(clap::ArgAction::Append)
+                        .num_args(1..)
+                        .conflicts_with("bam-files")
+                        .conflicts_with("bam-file-cache-directory"),
+                )
+                .group(
+                    ArgGroup::new("bam-file-cache")
+                        .args(["bam-file-cache-directory", "bam-file-cache-names"]),
                 )
                 .arg(
                     Arg::new("threads")
@@ -1735,7 +1775,7 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                 .arg(
                     Arg::new("discard-unmapped")
                         .long("discard-unmapped")
-                        .requires("bam-file-cache-directory")
+                        .requires("bam-file-cache")
                         .action(clap::ArgAction::SetTrue),
                 )
                 .arg(


### PR DESCRIPTION
## Summary
- add `--bam-file-cache-names` argument for explicit BAM cache filenames
- log which reads are cached to which BAM file
- document new caching option
- refactor BAM cache naming logic into a reusable helper
- stabilize cache directory test using a read-only temp dir

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_689d67582538832aba961aa7f8319b37