### PR TITLE
Add dependency checks for x-mapper mapping program

### DIFF
--- a/src/bam_generator.rs
+++ b/src/bam_generator.rs
@@ -3,6 +3,8 @@ use std::io::Read;
 use std::process;
 use std::sync::atomic::{compiler_fence, Ordering};
 
+use crate::external_command_checker;
+
 use filter::*;
 use mapping_index_maintenance::MappingIndex;
 use mapping_parameters::ReadFormat;
@@ -54,6 +56,32 @@ pub enum MappingProgram {
     MINIMAP2_NO_PRESET,
     STROBEALIGN,
     X_MAPPER,
+}
+
+impl MappingProgram {
+    pub fn check_dependencies(&self) {
+        match self {
+            MappingProgram::BWA_MEM => {
+                external_command_checker::check_for_bwa();
+            }
+            MappingProgram::BWA_MEM2 => {
+                external_command_checker::check_for_bwa_mem2();
+            }
+            MappingProgram::MINIMAP2_SR
+            | MappingProgram::MINIMAP2_ONT
+            | MappingProgram::MINIMAP2_PB
+            | MappingProgram::MINIMAP2_HIFI
+            | MappingProgram::MINIMAP2_NO_PRESET => {
+                external_command_checker::check_for_minimap2();
+            }
+            MappingProgram::STROBEALIGN => {
+                external_command_checker::check_for_strobealign();
+            }
+            MappingProgram::X_MAPPER => {
+                external_command_checker::check_for_x_mapper();
+            }
+        }
+    }
 }
 
 pub struct BamFileNamedReader {

--- a/src/bin/coverm.rs
+++ b/src/bin/coverm.rs
@@ -892,27 +892,7 @@ fn parse_mapping_program(m: &clap::ArgMatches) -> MappingProgram {
             m.get_one::<String>("mapper")
         ),
     };
-    match mapping_program {
-        MappingProgram::BWA_MEM => {
-            external_command_checker::check_for_bwa();
-        }
-        MappingProgram::BWA_MEM2 => {
-            external_command_checker::check_for_bwa_mem2();
-        }
-        MappingProgram::MINIMAP2_SR
-        | MappingProgram::MINIMAP2_ONT
-        | MappingProgram::MINIMAP2_HIFI
-        | MappingProgram::MINIMAP2_PB
-        | MappingProgram::MINIMAP2_NO_PRESET => {
-            external_command_checker::check_for_minimap2();
-        }
-        MappingProgram::STROBEALIGN => {
-            external_command_checker::check_for_strobealign();
-        }
-        MappingProgram::X_MAPPER => {
-            external_command_checker::check_for_x_mapper();
-        }
-    }
+    mapping_program.check_dependencies();
     mapping_program
 }
 

--- a/src/coverage_printer.rs
+++ b/src/coverage_printer.rs
@@ -197,9 +197,8 @@ pub fn print_sparse_cached_coverage_taker(
                         }
                         coverage_totals[*i] = Some(total_coverage);
 
-                        if reads_mapped_per_sample.is_some() {
-                            let reads_mapped =
-                                &reads_mapped_per_sample.as_ref().unwrap()[current_stoit_index];
+                        if let Some(reads_mapped_per_sample) = reads_mapped_per_sample.as_ref() {
+                            let reads_mapped = &reads_mapped_per_sample[current_stoit_index];
                             let fraction_mapped = reads_mapped.num_mapped_reads as f32
                                 / reads_mapped.num_reads as f32;
                             coverage_multipliers[*i] = Some(fraction_mapped);

--- a/src/mapping_index_maintenance.rs
+++ b/src/mapping_index_maintenance.rs
@@ -185,7 +185,7 @@ fn check_for_bwa_index_existence(reference_path: &str, mapping_program: &Mapping
     if num_existing == 0 {
         false
     } else if num_existing == num_extensions {
-        return true;
+        true
     } else {
         error!("BWA index appears to be incomplete, cannot continue.");
         process::exit(1);

--- a/src/mapping_parameters.rs
+++ b/src/mapping_parameters.rs
@@ -248,27 +248,27 @@ impl<'a> Iterator for SingleReferenceMappingParameters<'a> {
         } else if self.iter_interleaved_index < self.interleaved.len() {
             let i = self.iter_interleaved_index;
             self.iter_interleaved_index += 1;
-            return Some(OneSampleMappingParameters {
+            Some(OneSampleMappingParameters {
                 reference: self.reference,
                 read_format: ReadFormat::Interleaved,
                 read1: self.interleaved[i],
                 read2: None,
                 threads: self.threads,
                 mapping_options: self.mapping_options,
-            });
+            })
         } else if self.iter_unpaired_index < self.unpaired.len() {
             let i = self.iter_unpaired_index;
             self.iter_unpaired_index += 1;
-            return Some(OneSampleMappingParameters {
+            Some(OneSampleMappingParameters {
                 reference: self.reference,
                 read_format: ReadFormat::Single,
                 read1: self.unpaired[i],
                 read2: None,
                 threads: self.threads,
                 mapping_options: self.mapping_options,
-            });
+            })
         } else {
-            return None;
+            None
         }
     }
 }

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -3789,7 +3789,7 @@ genome6~random_sequence_length_11003	0	0	0
             None,
             None,
         );
-        assert_eq!(cmd.split_whitespace().next().unwrap(), "x-mapper");
+        assert!(cmd.starts_with("bash -c \"x-mapper"));
         assert!(cmd.contains("--reference 'ref.fa'"));
         assert!(cmd.contains("--queries 'reads.fq'"));
         assert!(cmd.contains("--out-sam -"));


### PR DESCRIPTION
## Summary
- add a `MappingProgram::check_dependencies` helper so each mapper, including x-mapper, validates its external tools when selected
- update the CLI parser to invoke the shared dependency check and adjust the x-mapper command test expectation
- resolve recent clippy findings uncovered by the hook

## Testing
- cargo fmt
- cargo clippy -- -D warnings
- cargo test


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6913ae10e08c832aa140d2f16ba26f87)