### PR TITLE
Add --consensus-genomes-folder option to emit per-sample consensus FASTA for covered genomes

### DIFF
--- a/src/bin/coverm.rs
+++ b/src/bin/coverm.rs
@@ -5,6 +5,7 @@ use coverm::coverage_printer::*;
 use coverm::coverage_takers::*;
 use coverm::external_command_checker;
 use coverm::filter;
+use coverm::genome::ConsensusGenomeOutputConfig;
 use coverm::genome_exclusion::*;
 use coverm::genomes_and_contigs::GenomesAndContigs;
 use coverm::mapping_index_maintenance::check_reference_existence;
@@ -58,6 +59,16 @@ fn main() {
             bird_tool_utils::clap_utils::print_full_help_if_needed(m, genome_full_help());
             set_log_level(m, true);
             manually_check_args_at_runtime(m);
+            if m.contains_id("consensus-genomes-folder")
+                && !(m.contains_id("genome-fasta-files")
+                    || m.contains_id("genome-fasta-directory")
+                    || m.contains_id("genome-fasta-list"))
+            {
+                error!(
+                    "--consensus-genomes-folder requires genomes be supplied via --genome-fasta-files, --genome-fasta-directory, or --genome-fasta-list"
+                );
+                process::exit(1);
+            }
             print_stream = OutputWriter::generate(m.get_one::<String>("output-file").map(|x| &**x));
 
             let genome_names_content: Vec<u8>;
@@ -1210,6 +1221,12 @@ fn run_genome<
     let flag_filter = FilterParameters::generate_from_clap(m).flag_filters;
     let single_genome = m.get_flag("single-genome");
     let threads = *m.get_one::<u16>("threads").unwrap();
+    let consensus_output_config = m
+        .get_one::<String>("consensus-genomes-folder")
+        .map(|folder| ConsensusGenomeOutputConfig {
+            folder: folder.to_string(),
+            min_coverage: *m.get_one::<u32>("min-consensus-coverage").unwrap(),
+        });
     let reads_mapped = match separator.is_some() || single_genome {
         true => coverm::genome::mosdepth_genome_coverage(
             bam_generators,
@@ -1220,6 +1237,7 @@ fn run_genome<
             &flag_filter,
             single_genome,
             threads,
+            consensus_output_config.as_ref(),
         ),
 
         false => match genomes_and_contigs_option {
@@ -1231,6 +1249,7 @@ fn run_genome<
                 &flag_filter,
                 &mut estimators_and_taker.estimators,
                 threads,
+                consensus_output_config.as_ref(),
             ),
             None => unreachable!(),
         },

--- a/src/bin/coverm.rs
+++ b/src/bin/coverm.rs
@@ -1,11 +1,11 @@
 extern crate coverm;
 use coverm::bam_generator::*;
 use coverm::cli::*;
+use coverm::consensus_genome::ConsensusGenomeOutputConfig;
 use coverm::coverage_printer::*;
 use coverm::coverage_takers::*;
 use coverm::external_command_checker;
 use coverm::filter;
-use coverm::genome::ConsensusGenomeOutputConfig;
 use coverm::genome_exclusion::*;
 use coverm::genomes_and_contigs::GenomesAndContigs;
 use coverm::mapping_index_maintenance::check_reference_existence;

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -847,6 +847,13 @@ pub fn genome_full_help() -> Manual {
                 "Omit printing of genomes that have zero \
             coverage. [default: not set]",
             ))
+            .option(Opt::new("DIRECTORY").long("--consensus-genomes-folder").help(
+                "Write consensus sequences for genomes with non-zero coverage into this directory, one FASTA per genome for each sample. Requires genomes to be supplied via --genome-fasta-files, --genome-fasta-directory, or --genome-fasta-list. [default: not used]",
+            ))
+            .option(Opt::new("INT").long("--min-consensus-coverage").help(&format!(
+                "Minimum per-base coverage required for consensus base calls in --consensus-genomes-folder output. Positions below this coverage are output as N; coverage from reads with deletions/skips across a base is counted. {}",
+                default_roff("5")
+            )))
             .option(
                 Opt::new("DIRECTORY")
                     .long("--cache-unfiltered-bam-directory")
@@ -1452,6 +1459,14 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                     Arg::new("no-zeros")
                         .long("no-zeros")
                         .action(clap::ArgAction::SetTrue),
+                )
+                .arg(Arg::new("consensus-genomes-folder").long("consensus-genomes-folder"))
+                .arg(
+                    Arg::new("min-consensus-coverage")
+                        .long("min-consensus-coverage")
+                        .default_value("5")
+                        .value_parser(clap::value_parser!(u32))
+                        .requires("consensus-genomes-folder"),
                 )
                 .arg(
                     Arg::new("proper-pairs-only")

--- a/src/consensus_genome.rs
+++ b/src/consensus_genome.rs
@@ -1,0 +1,235 @@
+use rust_htslib::bam;
+use rust_htslib::bam::record::Cigar;
+use std::collections::{HashMap, HashSet};
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::Path;
+
+#[derive(Clone)]
+pub struct ConsensusGenomeOutputConfig {
+    pub folder: String,
+    pub min_coverage: u32,
+}
+
+#[derive(Clone, Copy, Default)]
+pub struct ConsensusBaseCounts {
+    a: u32,
+    c: u32,
+    g: u32,
+    t: u32,
+    skipped: u32,
+    coverage: u32,
+}
+
+impl ConsensusBaseCounts {
+    pub fn add_base(&mut self, base: u8) {
+        self.coverage += 1;
+        match base.to_ascii_uppercase() {
+            b'A' => self.a += 1,
+            b'C' => self.c += 1,
+            b'G' => self.g += 1,
+            b'T' => self.t += 1,
+            _ => {}
+        }
+    }
+
+    pub fn add_skipped(&mut self) {
+        self.coverage += 1;
+        self.skipped += 1;
+    }
+
+    pub fn consensus_base(&self, min_coverage: u32) -> u8 {
+        if self.coverage < min_coverage {
+            return b'N';
+        }
+
+        let mut best = 0;
+        let mut best_base = b'N';
+        if self.a > best {
+            best = self.a;
+            best_base = b'A';
+        }
+        if self.c > best {
+            best = self.c;
+            best_base = b'C';
+        }
+        if self.g > best {
+            best = self.g;
+            best_base = b'G';
+        }
+        if self.t > best {
+            best = self.t;
+            best_base = b'T';
+        }
+
+        if self.skipped > best {
+            b'-'
+        } else {
+            best_base
+        }
+    }
+}
+
+fn write_wrapped_fasta_record(file: &mut File, name: &str, sequence: &[u8]) {
+    writeln!(file, ">{name}").expect("Unable to write FASTA header");
+    for chunk in sequence.chunks(80) {
+        writeln!(file, "{}", std::str::from_utf8(chunk).unwrap())
+            .expect("Unable to write FASTA sequence");
+    }
+}
+
+pub fn safe_genome_file_name(genome_name: &str) -> String {
+    genome_name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
+pub fn update_consensus_counts_for_record(
+    counts: &mut [ConsensusBaseCounts],
+    record: &bam::record::Record,
+) {
+    let seq = record.seq().as_bytes();
+    let mut read_cursor: usize = 0;
+    let mut ref_cursor: usize = record.pos() as usize;
+    for cig in record.cigar().iter() {
+        match cig {
+            Cigar::Match(l) | Cigar::Diff(l) | Cigar::Equal(l) => {
+                for _ in 0..*l as usize {
+                    if ref_cursor < counts.len() && read_cursor < seq.len() {
+                        counts[ref_cursor].add_base(seq[read_cursor]);
+                    }
+                    ref_cursor += 1;
+                    read_cursor += 1;
+                }
+            }
+            Cigar::Del(l) | Cigar::RefSkip(l) => {
+                for _ in 0..*l as usize {
+                    if ref_cursor < counts.len() {
+                        counts[ref_cursor].add_skipped();
+                    }
+                    ref_cursor += 1;
+                }
+            }
+            Cigar::Ins(l) | Cigar::SoftClip(l) => {
+                read_cursor += *l as usize;
+            }
+            Cigar::HardClip(_) | Cigar::Pad(_) => {}
+        }
+    }
+}
+
+pub fn write_consensus_genomes_from_counts(
+    stoit_name: &str,
+    output_config: &ConsensusGenomeOutputConfig,
+    genomes_to_write: &[usize],
+    genome_names: &[String],
+    genome_to_tids: &[Vec<u32>],
+    tid_to_counts: &HashMap<u32, Vec<ConsensusBaseCounts>>,
+) {
+    let mut seen_sanitized = HashMap::new();
+    let mut seen_paths = HashSet::new();
+    for genome_index in genomes_to_write {
+        let genome_name = &genome_names[*genome_index];
+        let sanitized = safe_genome_file_name(genome_name);
+        if let Some(previous) = seen_sanitized.insert(sanitized.clone(), genome_name.clone()) {
+            panic!(
+                "Genome names '{}' and '{}' resolve to the same consensus output filename '{}.fna'",
+                previous, genome_name, sanitized
+            );
+        }
+        let relative_path = format!("{}/{}.fna", stoit_name, sanitized);
+        if !seen_paths.insert(relative_path.clone()) {
+            panic!(
+                "Duplicate consensus output path detected: {}",
+                relative_path
+            );
+        }
+    }
+
+    let sample_dir = Path::new(&output_config.folder).join(stoit_name);
+    create_dir_all(&sample_dir).expect("Unable to create consensus genome output directory");
+    for genome_index in genomes_to_write {
+        let genome_name = &genome_names[*genome_index];
+        let output_path = sample_dir.join(format!("{}.fna", safe_genome_file_name(genome_name)));
+        let mut output_file = File::create(&output_path).unwrap_or_else(|_| {
+            panic!(
+                "Unable to create consensus FASTA file for genome '{}' at {}",
+                genome_name,
+                output_path.display()
+            )
+        });
+        let mut consensus = Vec::new();
+        for tid in &genome_to_tids[*genome_index] {
+            if let Some(counts) = tid_to_counts.get(tid) {
+                for c in counts {
+                    consensus.push(c.consensus_base(output_config.min_coverage));
+                }
+            }
+        }
+        write_wrapped_fasta_record(&mut output_file, genome_name, &consensus);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_consensus_base_counts_threshold_and_skipped() {
+        let mut counts = ConsensusBaseCounts::default();
+        for _ in 0..4 {
+            counts.add_base(b'A');
+        }
+        assert_eq!(counts.consensus_base(5), b'N');
+        for _ in 0..5 {
+            counts.add_skipped();
+        }
+        assert_eq!(counts.consensus_base(5), b'-');
+    }
+
+    #[test]
+    fn test_consensus_no_nucleotide_evidence_is_n() {
+        let counts = ConsensusBaseCounts::default();
+        assert_eq!(counts.consensus_base(0), b'N');
+
+        let mut counts2 = ConsensusBaseCounts::default();
+        counts2.add_base(b'N');
+        assert_eq!(counts2.consensus_base(0), b'N');
+    }
+
+    #[test]
+    fn test_safe_genome_file_name() {
+        assert_eq!(safe_genome_file_name("a/b:c*?\"<d>|"), "a_b_c____d__");
+    }
+
+    #[test]
+    #[should_panic(expected = "resolve to the same consensus output filename")]
+    fn test_panics_on_sanitized_filename_collision() {
+        let cfg = ConsensusGenomeOutputConfig {
+            folder: tempfile::tempdir()
+                .unwrap()
+                .path()
+                .to_str()
+                .unwrap()
+                .to_string(),
+            min_coverage: 1,
+        };
+        let genomes = vec!["a/b".to_string(), "a:b".to_string()];
+        let genome_to_tids = vec![vec![0], vec![1]];
+        let mut tid_to_counts = HashMap::new();
+        tid_to_counts.insert(0, vec![ConsensusBaseCounts::default()]);
+        tid_to_counts.insert(1, vec![ConsensusBaseCounts::default()]);
+        write_consensus_genomes_from_counts(
+            "sample1",
+            &cfg,
+            &[0, 1],
+            &genomes,
+            &genome_to_tids,
+            &tid_to_counts,
+        );
+    }
+}

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -5,7 +5,10 @@ use std;
 use std::process;
 use FlagFilter;
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeSet, HashMap};
+use std::fs::{create_dir_all, File};
+use std::io::Write;
+use std::path::Path;
 use std::str;
 
 use bam_generator::*;
@@ -14,6 +17,150 @@ use genomes_and_contigs::GenomesAndContigs;
 use mosdepth_genome_coverage_estimators::*;
 use ReadsMapped;
 
+#[derive(Clone)]
+pub struct ConsensusGenomeOutputConfig {
+    pub folder: String,
+    pub min_coverage: u32,
+}
+
+#[derive(Clone, Copy, Default)]
+struct ConsensusBaseCounts {
+    a: u32,
+    c: u32,
+    g: u32,
+    t: u32,
+    skipped: u32,
+    coverage: u32,
+}
+
+impl ConsensusBaseCounts {
+    fn add_base(&mut self, base: u8) {
+        self.coverage += 1;
+        match base.to_ascii_uppercase() {
+            b'A' => self.a += 1,
+            b'C' => self.c += 1,
+            b'G' => self.g += 1,
+            b'T' => self.t += 1,
+            _ => {}
+        }
+    }
+
+    fn add_skipped(&mut self) {
+        self.coverage += 1;
+        self.skipped += 1;
+    }
+
+    fn consensus_base(&self, min_coverage: u32) -> u8 {
+        if self.coverage < min_coverage {
+            return b'N';
+        }
+        let mut best = self.a;
+        let mut best_base = b'A';
+        if self.c > best {
+            best = self.c;
+            best_base = b'C';
+        }
+        if self.g > best {
+            best = self.g;
+            best_base = b'G';
+        }
+        if self.t > best {
+            best = self.t;
+            best_base = b'T';
+        }
+        if self.skipped > best {
+            b'-'
+        } else {
+            best_base
+        }
+    }
+}
+
+fn write_wrapped_fasta_record(file: &mut File, name: &str, sequence: &[u8]) {
+    writeln!(file, ">{name}").expect("Unable to write FASTA header");
+    for chunk in sequence.chunks(80) {
+        writeln!(file, "{}", std::str::from_utf8(chunk).unwrap())
+            .expect("Unable to write FASTA sequence");
+    }
+}
+
+fn safe_genome_file_name(genome_name: &str) -> String {
+    genome_name
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
+            _ => c,
+        })
+        .collect()
+}
+
+fn update_consensus_counts_for_record(
+    counts: &mut [ConsensusBaseCounts],
+    record: &bam::record::Record,
+) {
+    let seq = record.seq().as_bytes();
+    let mut read_cursor: usize = 0;
+    let mut ref_cursor: usize = record.pos() as usize;
+    for cig in record.cigar().iter() {
+        match cig {
+            Cigar::Match(l) | Cigar::Diff(l) | Cigar::Equal(l) => {
+                for _ in 0..*l as usize {
+                    if ref_cursor < counts.len() && read_cursor < seq.len() {
+                        counts[ref_cursor].add_base(seq[read_cursor]);
+                    }
+                    ref_cursor += 1;
+                    read_cursor += 1;
+                }
+            }
+            Cigar::Del(l) | Cigar::RefSkip(l) => {
+                for _ in 0..*l as usize {
+                    if ref_cursor < counts.len() {
+                        counts[ref_cursor].add_skipped();
+                    }
+                    ref_cursor += 1;
+                }
+            }
+            Cigar::Ins(l) | Cigar::SoftClip(l) => {
+                read_cursor += *l as usize;
+            }
+            Cigar::HardClip(_) | Cigar::Pad(_) => {}
+        }
+    }
+}
+
+fn write_consensus_genomes_from_counts(
+    stoit_name: &str,
+    output_config: &ConsensusGenomeOutputConfig,
+    genomes_to_write: &[usize],
+    genome_names: &[String],
+    genome_to_tids: &[Vec<u32>],
+    tid_to_counts: &HashMap<u32, Vec<ConsensusBaseCounts>>,
+) {
+    let sample_dir = Path::new(&output_config.folder).join(stoit_name);
+    create_dir_all(&sample_dir).expect("Unable to create consensus genome output directory");
+    for genome_index in genomes_to_write {
+        let genome_name = &genome_names[*genome_index];
+        let output_path = sample_dir.join(format!("{}.fna", safe_genome_file_name(genome_name)));
+        let mut output_file = File::create(&output_path).unwrap_or_else(|_| {
+            panic!(
+                "Unable to create consensus FASTA file for genome '{}' at {}",
+                genome_name,
+                output_path.display()
+            )
+        });
+        let mut consensus = Vec::new();
+        for tid in &genome_to_tids[*genome_index] {
+            if let Some(counts) = tid_to_counts.get(tid) {
+                for c in counts {
+                    consensus.push(c.consensus_base(output_config.min_coverage));
+                }
+            }
+        }
+        write_wrapped_fasta_record(&mut output_file, genome_name, &consensus);
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
 pub fn mosdepth_genome_coverage_with_contig_names<
     R: NamedBamReader,
     G: NamedBamReaderGenerator<R>,
@@ -26,6 +173,7 @@ pub fn mosdepth_genome_coverage_with_contig_names<
     flag_filters: &FlagFilter,
     coverage_estimators: &mut [CoverageEstimator],
     threads: u16,
+    consensus_output_config: Option<&ConsensusGenomeOutputConfig>,
 ) -> Vec<ReadsMapped> {
     let mut reads_mapped_vector = vec![];
     let mut is_first_bam = true;
@@ -48,6 +196,7 @@ pub fn mosdepth_genome_coverage_with_contig_names<
             vec![vec!(); contigs_and_genomes.genomes.len()];
         // Reads mapped are only counted when the genome has non-zero coverage.
         let mut reads_mapped_in_each_genome: Vec<u64> = vec![0; contigs_and_genomes.genomes.len()];
+        let mut tid_to_consensus_counts: HashMap<u32, Vec<ConsensusBaseCounts>> = HashMap::new();
         for (tid, name) in target_names.iter().enumerate() {
             let genome_index = contigs_and_genomes.genome_index_of_contig(&String::from(
                 std::str::from_utf8(name).expect("UTF8 encoding error in BAM header file"),
@@ -58,6 +207,15 @@ pub fn mosdepth_genome_coverage_with_contig_names<
                     reference_number_to_genome_index.push(Some(i));
                     num_refs_in_genomes += 1;
                     genome_index_to_references[i].push(tid as u32);
+                    if consensus_output_config.is_some() {
+                        tid_to_consensus_counts.insert(
+                            tid as u32,
+                            vec![
+                                ConsensusBaseCounts::default();
+                                header.target_len(tid as u32).unwrap() as usize
+                            ],
+                        );
+                    }
                 }
                 None => {
                     reference_number_to_genome_index.push(None);
@@ -125,6 +283,11 @@ pub fn mosdepth_genome_coverage_with_contig_names<
             if !record.is_unmapped() {
                 // if mapped
                 let tid = original_tid as u32;
+                if consensus_output_config.is_some() {
+                    if let Some(counts) = tid_to_consensus_counts.get_mut(&tid) {
+                        update_consensus_counts_for_record(counts, &record);
+                    }
+                }
                 if tid != last_tid || doing_first {
                     debug!("Came across a new tid {tid}");
                     if doing_first {
@@ -264,6 +427,7 @@ pub fn mosdepth_genome_coverage_with_contig_names<
                 }
             }
             // print the genomes out
+            let mut genomes_with_nonzero_coverage: Vec<usize> = vec![];
             for (i, genome) in contigs_and_genomes.genomes.iter().enumerate() {
                 // Determine if any coverages are non-zero.
                 let coverages: Vec<f32> = per_genome_coverage_estimators[i]
@@ -275,6 +439,7 @@ pub fn mosdepth_genome_coverage_with_contig_names<
                 let any_nonzero_coverage = coverages.iter().any(|c| *c > 0.0);
                 if any_nonzero_coverage {
                     num_mapped_reads_total += reads_mapped_in_each_genome[i];
+                    genomes_with_nonzero_coverage.push(i);
                 }
                 if print_zero_coverage_genomes || any_nonzero_coverage {
                     coverage_taker.start_entry(i, genome);
@@ -300,8 +465,17 @@ pub fn mosdepth_genome_coverage_with_contig_names<
                     coverage_taker.finish_entry();
                 }
             }
+            if let Some(config) = consensus_output_config {
+                write_consensus_genomes_from_counts(
+                    stoit_name,
+                    config,
+                    &genomes_with_nonzero_coverage,
+                    &contigs_and_genomes.genomes,
+                    &genome_index_to_references,
+                    &tid_to_consensus_counts,
+                );
+            }
         }
-
         let reads_mapped = ReadsMapped {
             num_mapped_reads: num_mapped_reads_total,
             num_reads: bam_generated.num_detected_primary_alignments(),
@@ -429,6 +603,7 @@ pub fn mosdepth_genome_coverage<
     flag_filters: &FlagFilter,
     single_genome: bool,
     threads: u16,
+    consensus_output_config: Option<&ConsensusGenomeOutputConfig>,
 ) -> Vec<ReadsMapped> {
     let mut reads_mapped_vector = vec![];
     debug!(
@@ -444,6 +619,38 @@ pub fn mosdepth_genome_coverage<
         coverage_taker.start_stoit(stoit_name);
         let header = bam_generated.header().clone();
         let target_names = header.target_names();
+
+        let mut genome_names: Vec<String> = vec![];
+        let mut genome_name_to_index: HashMap<String, usize> = HashMap::new();
+        let mut genome_to_tids: Vec<Vec<u32>> = vec![];
+        let mut tid_to_consensus_counts: HashMap<u32, Vec<ConsensusBaseCounts>> = HashMap::new();
+        for tid in 0..header.target_count() {
+            let genome_name = if single_genome {
+                "genome1".to_string()
+            } else {
+                str::from_utf8(extract_genome(tid, &target_names, split_char))
+                    .unwrap()
+                    .to_string()
+            };
+            let genome_index = match genome_name_to_index.get(&genome_name) {
+                Some(i) => *i,
+                None => {
+                    let i = genome_names.len();
+                    genome_names.push(genome_name.clone());
+                    genome_name_to_index.insert(genome_name, i);
+                    genome_to_tids.push(vec![]);
+                    i
+                }
+            };
+            genome_to_tids[genome_index].push(tid);
+            if consensus_output_config.is_some() {
+                tid_to_consensus_counts.insert(
+                    tid,
+                    vec![ConsensusBaseCounts::default(); header.target_len(tid).unwrap() as usize],
+                );
+            }
+        }
+        let mut genomes_with_nonzero_coverage: Vec<usize> = vec![];
 
         let fill_genome_length_forwards = |current_tid, target_genome: Option<&[u8]>| -> Vec<u64> {
             // Iterating reads skips over contigs with no mapped reads, but the
@@ -532,6 +739,11 @@ pub fn mosdepth_genome_coverage<
             if !record.is_unmapped() {
                 // if reference has changed, finish a genome or not
                 let tid = original_tid as u32;
+                if consensus_output_config.is_some() {
+                    if let Some(counts) = tid_to_consensus_counts.get_mut(&tid) {
+                        update_consensus_counts_for_record(counts, &record);
+                    }
+                }
                 let current_genome: &[u8] = match single_genome {
                     true => "".as_bytes(),
                     false => extract_genome(tid, &target_names, split_char),
@@ -640,6 +852,12 @@ pub fn mosdepth_genome_coverage<
                         );
                         if positive_coverage {
                             num_mapped_reads_total += num_mapped_reads_in_current_genome;
+                            if let Some(genome) = last_genome {
+                                let gname = str::from_utf8(genome).unwrap();
+                                if let Some(i) = genome_name_to_index.get(gname) {
+                                    genomes_with_nonzero_coverage.push(*i);
+                                }
+                            }
                         }
                         num_mapped_reads_in_current_genome = 0;
                         last_genome = Some(current_genome);
@@ -774,7 +992,26 @@ pub fn mosdepth_genome_coverage<
             );
             if positive_coverage {
                 num_mapped_reads_total += num_mapped_reads_in_current_genome;
+                if let Some(genome) = last_genome {
+                    let gname = str::from_utf8(genome).unwrap();
+                    if let Some(i) = genome_name_to_index.get(gname) {
+                        genomes_with_nonzero_coverage.push(*i);
+                    }
+                }
             }
+        }
+
+        if let Some(config) = consensus_output_config {
+            genomes_with_nonzero_coverage.sort_unstable();
+            genomes_with_nonzero_coverage.dedup();
+            write_consensus_genomes_from_counts(
+                stoit_name,
+                config,
+                &genomes_with_nonzero_coverage,
+                &genome_names,
+                &genome_to_tids,
+                &tid_to_consensus_counts,
+            );
         }
 
         let reads_mapped = ReadsMapped {
@@ -968,6 +1205,7 @@ mod tests {
                 &flags,
                 single_genome,
                 1,
+                None,
             );
         }
         assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
@@ -1007,6 +1245,7 @@ mod tests {
                 &flags,
                 single_genome,
                 1,
+                None,
             );
         }
         assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
@@ -1042,6 +1281,7 @@ mod tests {
                 &flags,
                 coverage_estimators,
                 1,
+                None,
             );
         }
         assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
@@ -1079,6 +1319,7 @@ mod tests {
                 &flags,
                 coverage_estimators,
                 1,
+                None,
             );
         }
         assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
@@ -1983,5 +2224,22 @@ mod tests {
             }),
             reads_mapped
         );
+    }
+    #[test]
+    fn test_consensus_base_counts_threshold_and_skipped() {
+        let mut counts = ConsensusBaseCounts::default();
+        for _ in 0..4 {
+            counts.add_base(b'A');
+        }
+        assert_eq!(counts.consensus_base(5), b'N');
+        for _ in 0..5 {
+            counts.add_skipped();
+        }
+        assert_eq!(counts.consensus_base(5), b'-');
+    }
+
+    #[test]
+    fn test_safe_genome_file_name() {
+        assert_eq!(safe_genome_file_name("a/b:c*?\"<d>|"), "a_b_c____d__");
     }
 }

--- a/src/genome.rs
+++ b/src/genome.rs
@@ -6,159 +6,14 @@ use std::process;
 use FlagFilter;
 
 use std::collections::{BTreeSet, HashMap};
-use std::fs::{create_dir_all, File};
-use std::io::Write;
-use std::path::Path;
 use std::str;
 
 use bam_generator::*;
+use consensus_genome::*;
 use coverage_takers::*;
 use genomes_and_contigs::GenomesAndContigs;
 use mosdepth_genome_coverage_estimators::*;
 use ReadsMapped;
-
-#[derive(Clone)]
-pub struct ConsensusGenomeOutputConfig {
-    pub folder: String,
-    pub min_coverage: u32,
-}
-
-#[derive(Clone, Copy, Default)]
-struct ConsensusBaseCounts {
-    a: u32,
-    c: u32,
-    g: u32,
-    t: u32,
-    skipped: u32,
-    coverage: u32,
-}
-
-impl ConsensusBaseCounts {
-    fn add_base(&mut self, base: u8) {
-        self.coverage += 1;
-        match base.to_ascii_uppercase() {
-            b'A' => self.a += 1,
-            b'C' => self.c += 1,
-            b'G' => self.g += 1,
-            b'T' => self.t += 1,
-            _ => {}
-        }
-    }
-
-    fn add_skipped(&mut self) {
-        self.coverage += 1;
-        self.skipped += 1;
-    }
-
-    fn consensus_base(&self, min_coverage: u32) -> u8 {
-        if self.coverage < min_coverage {
-            return b'N';
-        }
-        let mut best = self.a;
-        let mut best_base = b'A';
-        if self.c > best {
-            best = self.c;
-            best_base = b'C';
-        }
-        if self.g > best {
-            best = self.g;
-            best_base = b'G';
-        }
-        if self.t > best {
-            best = self.t;
-            best_base = b'T';
-        }
-        if self.skipped > best {
-            b'-'
-        } else {
-            best_base
-        }
-    }
-}
-
-fn write_wrapped_fasta_record(file: &mut File, name: &str, sequence: &[u8]) {
-    writeln!(file, ">{name}").expect("Unable to write FASTA header");
-    for chunk in sequence.chunks(80) {
-        writeln!(file, "{}", std::str::from_utf8(chunk).unwrap())
-            .expect("Unable to write FASTA sequence");
-    }
-}
-
-fn safe_genome_file_name(genome_name: &str) -> String {
-    genome_name
-        .chars()
-        .map(|c| match c {
-            '/' | '\\' | ':' | '*' | '?' | '"' | '<' | '>' | '|' => '_',
-            _ => c,
-        })
-        .collect()
-}
-
-fn update_consensus_counts_for_record(
-    counts: &mut [ConsensusBaseCounts],
-    record: &bam::record::Record,
-) {
-    let seq = record.seq().as_bytes();
-    let mut read_cursor: usize = 0;
-    let mut ref_cursor: usize = record.pos() as usize;
-    for cig in record.cigar().iter() {
-        match cig {
-            Cigar::Match(l) | Cigar::Diff(l) | Cigar::Equal(l) => {
-                for _ in 0..*l as usize {
-                    if ref_cursor < counts.len() && read_cursor < seq.len() {
-                        counts[ref_cursor].add_base(seq[read_cursor]);
-                    }
-                    ref_cursor += 1;
-                    read_cursor += 1;
-                }
-            }
-            Cigar::Del(l) | Cigar::RefSkip(l) => {
-                for _ in 0..*l as usize {
-                    if ref_cursor < counts.len() {
-                        counts[ref_cursor].add_skipped();
-                    }
-                    ref_cursor += 1;
-                }
-            }
-            Cigar::Ins(l) | Cigar::SoftClip(l) => {
-                read_cursor += *l as usize;
-            }
-            Cigar::HardClip(_) | Cigar::Pad(_) => {}
-        }
-    }
-}
-
-fn write_consensus_genomes_from_counts(
-    stoit_name: &str,
-    output_config: &ConsensusGenomeOutputConfig,
-    genomes_to_write: &[usize],
-    genome_names: &[String],
-    genome_to_tids: &[Vec<u32>],
-    tid_to_counts: &HashMap<u32, Vec<ConsensusBaseCounts>>,
-) {
-    let sample_dir = Path::new(&output_config.folder).join(stoit_name);
-    create_dir_all(&sample_dir).expect("Unable to create consensus genome output directory");
-    for genome_index in genomes_to_write {
-        let genome_name = &genome_names[*genome_index];
-        let output_path = sample_dir.join(format!("{}.fna", safe_genome_file_name(genome_name)));
-        let mut output_file = File::create(&output_path).unwrap_or_else(|_| {
-            panic!(
-                "Unable to create consensus FASTA file for genome '{}' at {}",
-                genome_name,
-                output_path.display()
-            )
-        });
-        let mut consensus = Vec::new();
-        for tid in &genome_to_tids[*genome_index] {
-            if let Some(counts) = tid_to_counts.get(tid) {
-                for c in counts {
-                    consensus.push(c.consensus_base(output_config.min_coverage));
-                }
-            }
-        }
-        write_wrapped_fasta_record(&mut output_file, genome_name, &consensus);
-    }
-}
 
 #[allow(clippy::too_many_arguments)]
 pub fn mosdepth_genome_coverage_with_contig_names<
@@ -2224,22 +2079,5 @@ mod tests {
             }),
             reads_mapped
         );
-    }
-    #[test]
-    fn test_consensus_base_counts_threshold_and_skipped() {
-        let mut counts = ConsensusBaseCounts::default();
-        for _ in 0..4 {
-            counts.add_base(b'A');
-        }
-        assert_eq!(counts.consensus_base(5), b'N');
-        for _ in 0..5 {
-            counts.add_skipped();
-        }
-        assert_eq!(counts.consensus_base(5), b'-');
-    }
-
-    #[test]
-    fn test_safe_genome_file_name() {
-        assert_eq!(safe_genome_file_name("a/b:c*?\"<d>|"), "a_b_c____d__");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod bam_generator;
 pub mod cli;
+pub mod consensus_genome;
 pub mod contig;
 pub mod coverage_printer;
 pub mod coverage_takers;

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -2363,6 +2363,78 @@ genome6~random_sequence_length_11003	0	0	0
     }
 
     #[test]
+    fn test_consensus_genomes_folder_requires_genome_fasta_inputs() {
+        let out_dir = tempfile::tempdir().unwrap();
+        let out = out_dir.path().to_str().unwrap();
+
+        Assert::main_binary()
+            .with_args(&[
+                "genome",
+                "-b",
+                "tests/data/2seqs.bad_read.1.bam",
+                "-s",
+                "~",
+                "--consensus-genomes-folder",
+                out,
+            ])
+            .fails()
+            .stderr()
+            .contains(
+                "--consensus-genomes-folder requires genomes be supplied via --genome-fasta-files, --genome-fasta-directory, or --genome-fasta-list",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_consensus_genomes_folder_outputs_filtered_genomes() {
+        let out_dir = tempfile::tempdir().unwrap();
+        let out = out_dir.path().to_str().unwrap();
+
+        Assert::main_binary()
+            .with_args(&[
+                "genome",
+                "--genome-fasta-files",
+                "tests/data/set1/500kb.fna",
+                "tests/data/set1/1mbp.fna",
+                "-t",
+                "5",
+                "--methods",
+                "covered_fraction",
+                "--min-covered-fraction",
+                "0",
+                "--single",
+                "tests/data/set1/1read.actually_fasta.fq",
+                "-p",
+                "minimap2-sr",
+                "--consensus-genomes-folder",
+                out,
+            ])
+            .succeeds()
+            .unwrap();
+
+        let sample_dir = out_dir.path().join("1read.actually_fasta.fq");
+        assert!(sample_dir.exists());
+
+        let expected_present = sample_dir.join("1mbp.fna");
+        let expected_absent = sample_dir.join("500kb.fna");
+        assert!(expected_present.exists());
+        assert!(!expected_absent.exists());
+
+        let mut fasta = String::new();
+        std::fs::File::open(expected_present)
+            .unwrap()
+            .read_to_string(&mut fasta)
+            .unwrap();
+        assert!(fasta.starts_with(
+            ">1mbp
+"
+        ));
+        assert!(fasta.lines().skip(1).all(|l| l
+            .chars()
+            .all(|c| matches!(c, 'A' | 'C' | 'G' | 'T' | 'N' | '-'))));
+    }
+
+    #[test]
     fn test_contig_unsorted_bam_file() {
         Assert::main_binary()
             .with_args(&["contig", "-b", "tests/data/2seqs.bad_read.1.unsorted.bam"])


### PR DESCRIPTION
### Motivation

- Provide an option to emit consensus sequences for genomes with non-zero coverage per sample so downstream inspection or export of consensus FASTA is possible.
- Allow callers to control minimum per-base coverage used for consensus base calls and ensure the option is only used when genome FASTA inputs are provided.

### Description

- Added CLI flags `--consensus-genomes-folder` and `--min-consensus-coverage` (default 5) and runtime validation that `--consensus-genomes-folder` requires one of `--genome-fasta-files`, `--genome-fasta-directory`, or `--genome-fasta-list`.
- Introduced `ConsensusGenomeOutputConfig` and threaded an `Option<&ConsensusGenomeOutputConfig>` through `mosdepth_genome_coverage` and `mosdepth_genome_coverage_with_contig_names` so consensus generation is optionally performed during coverage calculation.
- Implemented per-base `ConsensusBaseCounts`, logic to update counts from BAM records respecting CIGAR operations (matches, deletions/ref-skips, insertions/clips), and a routine to write wrapped FASTA records into a per-sample directory with filesystem-safe genome filenames.
- Updated callers and tests to accommodate the new parameter and added helper functions `safe_genome_file_name`, `write_wrapped_fasta_record`, and consensus-writing plumbing that only writes genomes with non-zero coverage.

### Testing

- Added unit tests `test_consensus_base_counts_threshold_and_skipped` and `test_safe_genome_file_name`, and integration tests `test_consensus_genomes_folder_requires_genome_fasta_inputs` and `test_consensus_genomes_folder_outputs_filtered_genomes` to verify behavior and CLI validation; these tests were run as part of the test suite and succeeded.
- Existing coverage-related tests were kept and executed with the new optional parameter set to `None` where appropriate, and they succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b637b2292c832a818bfc47ba3b6417)