### PR TITLE
Add mean_zero_coverage_length coverage method

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,7 @@ The difference coverage measures would be:
 | count | 2 |  | 2 reads are mapped. |
 | reads_per_base | 0.002 | 2/1000 | 2 reads are mapped over 1000bp. |
 | anir | 0.95 | (sum identity of reads)/number of reads | Average BLAST-like identity of mapped reads |
+| mean_zero_coverage_length | 326.67 | (200+20+760)/3 | Average length of the regions with zero coverage. Here the contig has three uncovered stretches (before, between and after the two reads) of 200, 20 and 760 bp. A contig or genome with no reads mapped is treated as a single zero-coverage region spanning its whole length, and one with no zero-coverage positions is reported as 0. |
 | metabat | contigLen 1000, totalAvgDepth 0.02235294, bam depth 0.02235294, variance 0.01961962 | | Reproduction of the [MetaBAT](https://bitbucket.org/berkeleylab/metabat) 'jgi_summarize_bam_contig_depths' tool output, producing [identical output](https://bitbucket.org/berkeleylab/metabat/issues/48/jgi_summarize_bam_contig_depths-coverage). |
 | coverage_histogram | 20 bases with coverage 1, 980 bases with coverage 0 | | The number of positions with each different coverage are tallied. |
 | rpkm | 1000000 | 2 * 10^9 / 1000 / 2 | Calculation here assumes no other reads map to other contigs. See https://haroldpimentel.wordpress.com/2014/05/08/what-the-fpkm-a-review-rna-seq-expression-units/ for an explanation of RPKM and TPM. Note that this calculates the RPKM contigs (or genomes in `genome` mode), not individual genes.|

--- a/src/bin/coverm.rs
+++ b/src/bin/coverm.rs
@@ -1222,6 +1222,10 @@ impl EstimatorsAndTaker {
                     "anir" => {
                         estimators.push(CoverageEstimator::new_estimator_anir());
                     }
+                    "mean_zero_coverage_length" => {
+                        estimators
+                            .push(CoverageEstimator::new_estimator_mean_zero_coverage_length());
+                    }
                     "strobealign-aemb" => {
                         if methods.len() > 1 {
                             error!("Cannot (currently) specify the strobealign-aemb method with any other coverage methods");
@@ -1285,6 +1289,9 @@ impl EstimatorsAndTaker {
                     CoverageEstimator::ReferenceLengthCalculator { .. } => die("length"),
                     CoverageEstimator::ReadsPerBaseCalculator { .. } => die("reads_per_base"),
                     CoverageEstimator::AverageIdentityEstimator { .. } => die("anir"),
+                    CoverageEstimator::MeanZeroCoverageLengthEstimator { .. } => {
+                        die("mean_zero_coverage_length")
+                    }
                     CoverageEstimator::StrobealignAembEstimator { .. } => die("strobealign-aemb"),
                     _ => {}
                 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -714,6 +714,7 @@ pub fn contig_full_help() -> Manual {
                     &[&monospace_roff("metabat"), "(\"MetaBAT adjusted coverage\") Coverage as defined in Kang et al 2015 https://doi.org/10.7717/peerj.1165"],
                     &[&monospace_roff("reads_per_base"), "Number of reads aligned divided by the length of the contig"],
                     &[&monospace_roff("anir"), "Average BLAST-like identity of mapped reads"],
+                    &[&monospace_roff("mean_zero_coverage_length"), "Average length (in base pairs) of the regions of each contig that have zero coverage. Contigs with no zero-coverage regions are reported as 0"],
                     &[&monospace_roff("rpkm"), "Reads mapped per kilobase of contig, per million mapped reads"],
                     &[&monospace_roff("tpm"), "Transcripts Per Million as described in Li et al 2010 https://doi.org/10.1093/bioinformatics/btp692"],
                 ]),
@@ -963,6 +964,7 @@ pub fn genome_full_help() -> Manual {
                     &[&monospace_roff("count"), "Number of reads aligned to each genome. Note that supplementary alignments are not counted."],
                     &[&monospace_roff("reads_per_base"), "Number of reads aligned divided by the length of the genome"],
                     &[&monospace_roff("anir"), "Average BLAST-like identity of mapped reads"],
+                    &[&monospace_roff("mean_zero_coverage_length"), "Average length (in base pairs) of the regions of each genome that have zero coverage. Genomes with no zero-coverage regions are reported as 0"],
                     &[&monospace_roff("rpkm"), "Reads mapped per kilobase of genome, per million mapped reads"],
                     &[&monospace_roff("tpm"), "Transcripts Per Million as described in Li et al 2010 https://doi.org/10.1093/bioinformatics/btp692"],
                 ])
@@ -1595,6 +1597,7 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                             "count",
                             "reads_per_base",
                             "anir",
+                            "mean_zero_coverage_length",
                             "rpkm",
                             "tpm",
                         ])
@@ -2016,6 +2019,7 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                             "metabat",
                             "reads_per_base",
                             "anir",
+                            "mean_zero_coverage_length",
                             "rpkm",
                             "tpm",
                             "strobealign-aemb",

--- a/src/contig.rs
+++ b/src/contig.rs
@@ -577,6 +577,21 @@ mod tests {
     }
 
     #[test]
+    fn test_mean_zero_coverage_length_estimator() {
+        // seq1 has reads mapped and so has its zero-coverage regions measured,
+        // while seq2 has no reads mapped at all and so is a single
+        // zero-coverage region spanning its whole length (1000bp).
+        test_with_stream(
+            &("2seqs.reads_for_seq1\tseq1\t68.25\n".to_owned()
+                + "2seqs.reads_for_seq1\tseq2\t1000\n"),
+            generate_named_bam_readers_from_bam_files(vec!["tests/data/2seqs.reads_for_seq1.bam"]),
+            &mut vec![CoverageEstimator::new_estimator_mean_zero_coverage_length()],
+            true,
+            false,
+        );
+    }
+
+    #[test]
     fn test_reads_per_base_estimator() {
         test_with_stream(
             "7seqs.fna.bwa1/reads_for_seq1_and_seq2.1.fq.gz\tgenome1~random_sequence_length_11000\t0\n\

--- a/src/mosdepth_genome_coverage_estimators.rs
+++ b/src/mosdepth_genome_coverage_estimators.rs
@@ -77,6 +77,11 @@ pub enum CoverageEstimator {
         sum_identity: f64,
         num_reads: u64,
     },
+    MeanZeroCoverageLengthEstimator {
+        total_zero_coverage_bases: u64,
+        num_zero_coverage_regions: u64,
+        num_mapped_reads: u64,
+    },
     StrobealignAembEstimator {},
 }
 
@@ -99,6 +104,9 @@ impl CoverageEstimator {
             CoverageEstimator::ReadCountCalculator { .. } => vec!["Read Count"],
             CoverageEstimator::ReadsPerBaseCalculator { .. } => vec!["Reads per base"],
             CoverageEstimator::AverageIdentityEstimator { .. } => vec!["ANIr"],
+            CoverageEstimator::MeanZeroCoverageLengthEstimator { .. } => {
+                vec!["Mean Zero Coverage Length"]
+            }
             CoverageEstimator::StrobealignAembEstimator { .. } => vec!["Strobealign aemb"],
         }
     }
@@ -217,6 +225,13 @@ impl CoverageEstimator {
         CoverageEstimator::AverageIdentityEstimator {
             sum_identity: 0.0,
             num_reads: 0,
+        }
+    }
+    pub fn new_estimator_mean_zero_coverage_length() -> CoverageEstimator {
+        CoverageEstimator::MeanZeroCoverageLengthEstimator {
+            total_zero_coverage_bases: 0,
+            num_zero_coverage_regions: 0,
+            num_mapped_reads: 0,
         }
     }
     pub fn new_estimator_strobealign_aemb() -> CoverageEstimator {
@@ -358,6 +373,15 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             } => {
                 *sum_identity = 0.0;
                 *num_reads = 0;
+            }
+            CoverageEstimator::MeanZeroCoverageLengthEstimator {
+                ref mut total_zero_coverage_bases,
+                ref mut num_zero_coverage_regions,
+                ref mut num_mapped_reads,
+            } => {
+                *total_zero_coverage_bases = 0;
+                *num_zero_coverage_regions = 0;
+                *num_mapped_reads = 0;
             }
             CoverageEstimator::StrobealignAembEstimator { .. } => panic!("Programming error"),
         }
@@ -522,6 +546,31 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             } => {
                 *num_reads += num_mapped_reads_in_contig;
                 *sum_identity += sum_identity_in_contig;
+            }
+            CoverageEstimator::MeanZeroCoverageLengthEstimator {
+                ref mut total_zero_coverage_bases,
+                ref mut num_zero_coverage_regions,
+                ref mut num_mapped_reads,
+            } => {
+                *num_mapped_reads += num_mapped_reads_in_contig;
+                // Scan along the contig counting maximal runs of consecutive
+                // bases with zero coverage. Each run is a single zero-coverage
+                // region; the average region length is computed later in
+                // calculate_coverage. Contig ends are not excluded, matching the
+                // covered_fraction estimator.
+                let mut cumulative_sum: i32 = 0;
+                let mut previous_base_was_zero = false;
+                for current in ups_and_downs.iter() {
+                    cumulative_sum += current;
+                    let base_is_zero = cumulative_sum == 0;
+                    if base_is_zero {
+                        *total_zero_coverage_bases += 1;
+                        if !previous_base_was_zero {
+                            *num_zero_coverage_regions += 1;
+                        }
+                    }
+                    previous_base_was_zero = base_is_zero;
+                }
             }
             CoverageEstimator::StrobealignAembEstimator { .. } => unreachable!(),
         }
@@ -834,6 +883,33 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
                     (*sum_identity / *num_reads as f64) as f32
                 }
             }
+            CoverageEstimator::MeanZeroCoverageLengthEstimator {
+                total_zero_coverage_bases,
+                num_zero_coverage_regions,
+                num_mapped_reads,
+            } => {
+                let unobserved_bases: u64 = unobserved_contig_lengths.iter().sum();
+                if *num_mapped_reads == 0 {
+                    // No reads mapped to this entry at all, so the whole entry is
+                    // a single zero-coverage region spanning its full length.
+                    // Reporting the total length here (rather than the per-contig
+                    // average) keeps results identical to the print_zero_coverage
+                    // path, which only knows the entry's total length.
+                    return unobserved_bases as f32;
+                }
+                // Otherwise, average the zero-coverage regions found within the
+                // covered contigs together with each entirely-unobserved contig,
+                // which is itself a single region spanning its whole length.
+                let unobserved_regions =
+                    unobserved_contig_lengths.iter().filter(|&&l| l > 0).count() as u64;
+                let total_regions = *num_zero_coverage_regions + unobserved_regions;
+                let total_zero_bases = *total_zero_coverage_bases + unobserved_bases;
+                if total_regions == 0 {
+                    0.0
+                } else {
+                    total_zero_bases as f32 / total_regions as f32
+                }
+            }
             CoverageEstimator::StrobealignAembEstimator {} => unreachable!(),
         }
     }
@@ -927,6 +1003,9 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             CoverageEstimator::AverageIdentityEstimator { .. } => {
                 CoverageEstimator::new_estimator_anir()
             }
+            CoverageEstimator::MeanZeroCoverageLengthEstimator { .. } => {
+                CoverageEstimator::new_estimator_mean_zero_coverage_length()
+            }
             CoverageEstimator::StrobealignAembEstimator { .. } => {
                 CoverageEstimator::new_estimator_strobealign_aemb()
             }
@@ -946,6 +1025,7 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             | CoverageEstimator::ReadCountCalculator { .. }
             | CoverageEstimator::ReadsPerBaseCalculator { .. }
             | CoverageEstimator::AverageIdentityEstimator { .. }
+            | CoverageEstimator::MeanZeroCoverageLengthEstimator { .. }
             | CoverageEstimator::StrobealignAembEstimator { .. } => {
                 coverage_taker.add_single_coverage(coverage);
             }
@@ -986,6 +1066,22 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             CoverageEstimator::PileupCountsGenomeCoverageEstimator { .. } => {}
             CoverageEstimator::ReferenceLengthCalculator { .. } => {
                 coverage_taker.add_single_coverage(entry_length as f32);
+            }
+            CoverageEstimator::MeanZeroCoverageLengthEstimator {
+                num_mapped_reads, ..
+            } => {
+                // This path is reached either because no reads mapped to the
+                // entry at all (so the whole entry is a single zero-coverage
+                // region spanning its full length), or because the entry was
+                // fully covered (so there are no zero-coverage regions and the
+                // average length is 0). The number of mapped reads distinguishes
+                // the two cases, keeping this consistent with calculate_coverage.
+                let coverage = if *num_mapped_reads == 0 {
+                    entry_length as f32
+                } else {
+                    0.0
+                };
+                coverage_taker.add_single_coverage(coverage);
             }
         }
     }
@@ -1052,11 +1148,75 @@ impl MosdepthGenomeCoverageEstimator for CoverageEstimator {
             | CoverageEstimator::ReadsPerBaseCalculator {
                 observed_contig_length: _,
                 num_mapped_reads,
+            }
+            | CoverageEstimator::MeanZeroCoverageLengthEstimator {
+                num_mapped_reads, ..
             } => *num_mapped_reads,
             CoverageEstimator::AverageIdentityEstimator { num_reads, .. } => *num_reads,
             CoverageEstimator::StrobealignAembEstimator { .. } => {
                 panic!("Strobealign AEMB does not calculate number of mapped reads")
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Build the per-base delta ("ups and downs") array that yields the given
+    // per-base coverage profile, so tests can describe coverage directly.
+    fn ups_and_downs_from_coverage(coverage: &[i32]) -> Vec<i32> {
+        let mut ups_and_downs = Vec::with_capacity(coverage.len());
+        let mut previous = 0;
+        for c in coverage {
+            ups_and_downs.push(c - previous);
+            previous = *c;
+        }
+        ups_and_downs
+    }
+
+    #[test]
+    fn test_mean_zero_coverage_length_single_contig() {
+        let mut e = CoverageEstimator::new_estimator_mean_zero_coverage_length();
+        e.setup();
+        // Coverage profile with three zero-coverage regions of lengths 2, 1 and
+        // 3, so the average region length is (2 + 1 + 3) / 3 = 2.0.
+        let coverage = [0, 0, 1, 1, 0, 1, 0, 0, 0];
+        e.add_contig(&ups_and_downs_from_coverage(&coverage), 5, 0, 0.0);
+        assert_eq!(2.0, e.calculate_coverage(&[0]));
+    }
+
+    #[test]
+    fn test_mean_zero_coverage_length_fully_covered() {
+        let mut e = CoverageEstimator::new_estimator_mean_zero_coverage_length();
+        e.setup();
+        // Every base is covered, so there are no zero-coverage regions.
+        let coverage = [1, 2, 3, 2, 1];
+        e.add_contig(&ups_and_downs_from_coverage(&coverage), 3, 0, 0.0);
+        assert_eq!(0.0, e.calculate_coverage(&[0]));
+    }
+
+    #[test]
+    fn test_mean_zero_coverage_length_with_unobserved_contigs() {
+        let mut e = CoverageEstimator::new_estimator_mean_zero_coverage_length();
+        e.setup();
+        // One observed contig contributing three regions (2 + 1 + 3 = 6 bases),
+        // plus two entirely unobserved contigs of length 10 and 20, each a
+        // single zero-coverage region. So (6 + 10 + 20) / (3 + 2) = 7.2.
+        let coverage = [0, 0, 1, 1, 0, 1, 0, 0, 0];
+        e.add_contig(&ups_and_downs_from_coverage(&coverage), 5, 0, 0.0);
+        assert_eq!(7.2, e.calculate_coverage(&[10, 20]));
+    }
+
+    #[test]
+    fn test_mean_zero_coverage_length_only_unobserved() {
+        let mut e = CoverageEstimator::new_estimator_mean_zero_coverage_length();
+        e.setup();
+        // No reads mapped to this entry at all, so the whole entry is treated as
+        // a single zero-coverage region spanning its full length: 30 + 50 = 80.
+        // (This keeps results consistent with the print_zero_coverage path,
+        // which only knows the entry's total length.)
+        assert_eq!(80.0, e.calculate_coverage(&[30, 50]));
     }
 }

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -984,6 +984,29 @@ genome6	0",
     }
 
     #[test]
+    fn test_mean_zero_coverage_length_contig() {
+        // seq1 has reads mapped (so its internal zero-coverage gaps are
+        // measured), while seq2 has no reads mapped at all and so is reported as
+        // a single zero-coverage region spanning its whole 1000bp length.
+        Assert::main_binary()
+            .with_args(&[
+                "contig",
+                "-m",
+                "mean_zero_coverage_length",
+                "-b",
+                "tests/data/2seqs.reads_for_seq1.bam",
+            ])
+            .succeeds()
+            .stdout()
+            .contains(
+                "Contig\t2seqs.reads_for_seq1 Mean Zero Coverage Length\n\
+                 seq1\t68.25\n\
+                 seq2\t1000\n",
+            )
+            .unwrap();
+    }
+
+    #[test]
     fn test_metabat_include_supplementary() {
         Assert::main_binary()
             .with_args(&[


### PR DESCRIPTION
## Summary

Adds a new coverage method, `mean_zero_coverage_length`, that reports the **average length (in base pairs) of the regions of each contig or genome that have zero coverage**.

This builds on top of #290 (the `coverm makedb` branch), so its diff is included here; this PR's own changes are the new coverage method.

## Behaviour

- Within a covered contig, each maximal run of consecutive zero-coverage bases is one region; the method reports the average region length.
- A sequence with **no reads mapped at all** is treated as a single zero-coverage region spanning its whole length (e.g. an absent 1000 bp contig → `1000`).
- A sequence with **no zero-coverage positions** (fully covered) is reported as `0`.

## Cross-path consistency

Genome coverage is computed via two code paths — streaming (`--separator`) and non-streaming (`--genome-fasta-files`). For an entirely-unobserved multi-contig genome, the streaming path only knows the genome's *total* length (via `print_zero_coverage`). To keep results identical regardless of input format, an entry with zero mapped reads is defined as a single region of its full length. The estimator's `num_mapped_reads` is available in both `calculate_coverage` and `print_zero_coverage`, so both paths agree, and it also distinguishes an absent entry (→ length) from a fully-covered one (→ 0).

Like the other structural estimators (`length`, `count`, `reads_per_base`, `anir`), this method does not compute a covered fraction and so cannot be combined with `--min-covered-fraction > 0` (it errors with a clear message).

## Changes

- `src/mosdepth_genome_coverage_estimators.rs`: new `MeanZeroCoverageLengthEstimator` variant, all trait arms, and 4 unit tests.
- `src/bin/coverm.rs`: method dispatch and `--min-covered-fraction` incompatibility guard.
- `src/cli.rs`: added to both `genome`/`contig` value-parser lists and both help tables.
- `src/contig.rs`: end-to-end test (covered `seq1` → 68.25, uncovered `seq2` → 1000).
- `tests/test_cmdline.rs`: cmdline integration test.
- `README.md`: row in the calculation-methods table.

## Testing

- New unit, contig, and cmdline tests pass.
- `cargo clippy -- -D warnings` and `cargo fmt -- --check` are clean (enforced by the pre-commit hook).
- One unrelated, pre-existing test (`test_streaming_bam_file`) fails in this environment only because `samtools`/`bwa` are not installed.

The generated `docs/coverm-*.html` man pages were not regenerated, as that requires the `man`/`pandoc` tooling used at release time; the source README and CLI help text are updated.

https://claude.ai/code/session_0126FFDNupzAHRS5m74JA9Zp

---
_Generated by [Claude Code](https://claude.ai/code/session_0126FFDNupzAHRS5m74JA9Zp)_