### PR TITLE
Add --gff flag for per-gene coverage in contig and genome modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,15 @@ CoverM operates in several modes. Detailed usage information including examples 
 * [genome](https://wwood.github.io/CoverM/coverm-genome.html) - Calculate coverage of genomes
 * [contig](https://wwood.github.io/CoverM/coverm-contig.html) - Calculate coverage of contigs
 
+Both `genome` and `contig` modes accept a `--gff` option. When one or more GFF3
+files are provided, CoverM reports coverage statistics for each feature (gene)
+defined in the GFF files rather than for each genome or contig. The seqid (first
+column) of each GFF feature must match a reference sequence name. For example:
+
+```bash
+coverm contig -b mapping.bam --gff annotation.gff > per_gene_coverage.tsv
+```
+
 There are several utility modes as well:
 * [make](https://wwood.github.io/CoverM/coverm-make.html) - Generate BAM files through alignment
 * [filter](https://wwood.github.io/CoverM/coverm-filter.html) - Remove (or only keep) alignments with insufficient identity

--- a/src/bin/coverm.rs
+++ b/src/bin/coverm.rs
@@ -64,8 +64,13 @@ fn main() {
 
             let mut estimators_and_taker =
                 EstimatorsAndTaker::generate_from_clap(m, print_stream.clone());
+            let genome_entry_type = if m.contains_id("gff") {
+                "Gene"
+            } else {
+                "Genome"
+            };
             estimators_and_taker =
-                estimators_and_taker.print_headers("Genome", print_stream.clone());
+                estimators_and_taker.print_headers(genome_entry_type, print_stream.clone());
             let filter_params = FilterParameters::generate_from_clap(m);
             let separator = parse_separator(m);
 
@@ -504,6 +509,7 @@ fn main() {
             set_log_level(m, true);
             manually_check_args_at_runtime(m);
             let print_zeros = !m.get_flag("no-zeros");
+            let gff_genes = parse_gff_genes(m);
 
             // Add metabat filtering params since we are running contig
             let mut filter_params1 = FilterParameters::generate_from_clap(m);
@@ -515,8 +521,13 @@ fn main() {
 
             let mut estimators_and_taker =
                 EstimatorsAndTaker::generate_from_clap(m, print_stream.clone());
+            let contig_entry_type = if m.contains_id("gff") {
+                "Gene"
+            } else {
+                "Contig"
+            };
             estimators_and_taker =
-                estimators_and_taker.print_headers("Contig", print_stream.clone());
+                estimators_and_taker.print_headers(contig_entry_type, print_stream.clone());
 
             if let CoverageEstimator::StrobealignAembEstimator {} =
                 estimators_and_taker.estimators[0]
@@ -559,6 +570,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 } else if m.get_flag("sharded") {
                     external_command_checker::check_for_samtools();
@@ -575,6 +587,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 } else {
                     let bam_readers =
@@ -586,6 +599,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 }
             } else {
@@ -616,6 +630,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 } else if m.get_flag("sharded") {
                     let generator_sets = get_sharded_bam_readers(
@@ -631,6 +646,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 } else {
                     debug!("Not filtering..");
@@ -650,6 +666,7 @@ fn main() {
                         filter_params.flag_filters,
                         threads,
                         &mut print_stream,
+                        gff_genes.as_ref(),
                     );
                 }
             }
@@ -1178,6 +1195,25 @@ impl EstimatorsAndTaker {
     }
 }
 
+fn parse_gff_genes(m: &clap::ArgMatches) -> Option<Vec<coverm::gene::Gene>> {
+    if m.contains_id("gff") {
+        let gff_files: Vec<&str> = m.get_many::<String>("gff").unwrap().map(|s| &**s).collect();
+        let genes = coverm::gene::read_gff_files(&gff_files);
+        if genes.is_empty() {
+            error!("No features were read from the provided GFF file(s)");
+            process::exit(1);
+        }
+        info!(
+            "Read {} features in total from {} GFF file(s)",
+            genes.len(),
+            gff_files.len()
+        );
+        Some(genes)
+    } else {
+        None
+    }
+}
+
 fn parse_separator(m: &clap::ArgMatches) -> Option<u8> {
     let single_genome = m.get_flag("single-genome");
     if single_genome {
@@ -1210,6 +1246,31 @@ fn run_genome<
     let flag_filter = FilterParameters::generate_from_clap(m).flag_filters;
     let single_genome = m.get_flag("single-genome");
     let threads = *m.get_one::<u16>("threads").unwrap();
+
+    // When a GFF is provided, coverage is reported per-gene rather than
+    // per-genome, so bypass the genome grouping entirely.
+    if let Some(genes) = parse_gff_genes(m) {
+        let reads_mapped = coverm::gene::gene_coverage(
+            bam_generators,
+            &mut estimators_and_taker.taker,
+            &mut estimators_and_taker.estimators,
+            print_zeros,
+            &flag_filter,
+            threads,
+            &genes,
+        );
+        debug!("Finalising printing ..");
+        estimators_and_taker.printer.finalise_printing(
+            &estimators_and_taker.taker,
+            print_stream,
+            Some(&reads_mapped),
+            &estimators_and_taker.columns_to_normalise,
+            estimators_and_taker.rpkm_column,
+            estimators_and_taker.tpm_column,
+        );
+        return;
+    }
+
     let reads_mapped = match separator.is_some() || single_genome {
         true => coverm::genome::mosdepth_genome_coverage(
             bam_generators,
@@ -1715,15 +1776,27 @@ fn run_contig<
     flag_filters: FlagFilter,
     threads: u16,
     print_stream: &mut OutputWriter,
+    gff_genes: Option<&Vec<coverm::gene::Gene>>,
 ) {
-    let reads_mapped = coverm::contig::contig_coverage(
-        bam_readers,
-        &mut estimators_and_taker.taker,
-        &mut estimators_and_taker.estimators,
-        print_zeros,
-        &flag_filters,
-        threads,
-    );
+    let reads_mapped = match gff_genes {
+        Some(genes) => coverm::gene::gene_coverage(
+            bam_readers,
+            &mut estimators_and_taker.taker,
+            &mut estimators_and_taker.estimators,
+            print_zeros,
+            &flag_filters,
+            threads,
+            genes,
+        ),
+        None => coverm::contig::contig_coverage(
+            bam_readers,
+            &mut estimators_and_taker.taker,
+            &mut estimators_and_taker.estimators,
+            print_zeros,
+            &flag_filters,
+            threads,
+        ),
+    };
 
     debug!("Finalising printing ..");
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -567,6 +567,12 @@ pub fn contig_full_help() -> Manual {
                 reported as having zero coverage. \
                 {}", default_roff("0"))
             ))
+            .option(Opt::new("PATH ..").long("--gff").help(
+                "Report coverage statistics for each feature (gene) in these \
+                GFF3 file(s) rather than for each contig. The seqid (first \
+                column) of each feature must match a reference sequence name. \
+                [default: not used]",
+            ))
             .option(Opt::new("INT").long("--contig-end-exclusion").help(
                 &format!("Exclude bases at the ends of reference \
                 sequences from calculation {}",
@@ -815,6 +821,12 @@ pub fn genome_full_help() -> Manual {
                 &format!("Genomes with less covered bases than this are \
                 reported as having zero coverage. \
                 {}", default_roff("10"))
+            ))
+            .option(Opt::new("PATH ..").long("--gff").help(
+                "Report coverage statistics for each feature (gene) in these \
+                GFF3 file(s) rather than for each genome. The seqid (first \
+                column) of each feature must match a reference sequence name. \
+                [default: not used]",
             ))
             .option(Opt::new("INT").long("--contig-end-exclusion").help(
                 &format!("Exclude bases at the ends of reference \
@@ -1449,6 +1461,12 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                         .value_parser(clap::value_parser!(u64)),
                 )
                 .arg(
+                    Arg::new("gff")
+                        .long("gff")
+                        .action(clap::ArgAction::Append)
+                        .num_args(1..),
+                )
+                .arg(
                     Arg::new("no-zeros")
                         .long("no-zeros")
                         .action(clap::ArgAction::SetTrue),
@@ -1871,6 +1889,12 @@ Ben J. Woodcroft <benjwoodcroft near gmail.com>
                         .long("trim-max")
                         .default_value("95")
                         .value_parser(clap::value_parser!(f32)),
+                )
+                .arg(
+                    Arg::new("gff")
+                        .long("gff")
+                        .action(clap::ArgAction::Append)
+                        .num_args(1..),
                 )
                 .arg(
                     Arg::new("no-zeros")

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -1,0 +1,610 @@
+use std;
+use std::collections::HashMap;
+use std::io::BufRead;
+
+use rust_htslib::bam;
+use rust_htslib::bam::record::Cigar;
+
+use bam_generator::*;
+use coverage_takers::*;
+use mosdepth_genome_coverage_estimators::*;
+use nm;
+use FlagFilter;
+use ReadsMapped;
+
+/// A gene (or, more generally, a GFF feature) defined as a region of a contig.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Gene {
+    /// Name used in the output. Taken from the GFF `ID` attribute where
+    /// available, otherwise generated from the coordinates.
+    pub name: String,
+    /// Name of the contig (GFF seqid / column 1) the gene is located on.
+    pub contig: String,
+    /// 0-based, inclusive start of the gene on the contig.
+    pub start: u64,
+    /// 0-based, exclusive end of the gene on the contig.
+    pub end: u64,
+}
+
+/// Read one or more GFF3 files, returning one [`Gene`] per feature line. Lines
+/// beginning with `#` and blank lines are ignored, as is the FASTA section of a
+/// GFF3 file (everything after a `##FASTA` directive).
+pub fn read_gff_files(gff_files: &[&str]) -> Vec<Gene> {
+    let mut genes = vec![];
+    for gff_file in gff_files {
+        debug!("Reading GFF file {gff_file}");
+        let file = std::fs::File::open(gff_file)
+            .unwrap_or_else(|e| panic!("Failed to open GFF file '{}': {}", gff_file, e));
+        let reader = std::io::BufReader::new(file);
+        let mut num_read = 0;
+        for line_result in reader.lines() {
+            let line = line_result
+                .unwrap_or_else(|e| panic!("Error reading GFF file '{}': {}", gff_file, e));
+            let trimmed = line.trim_end();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed.starts_with('#') {
+                // The FASTA section that can be appended to GFF3 files starts
+                // with a ##FASTA directive - stop parsing this file there.
+                if trimmed.starts_with("##FASTA") {
+                    break;
+                }
+                continue;
+            }
+            let fields: Vec<&str> = trimmed.split('\t').collect();
+            if fields.len() < 9 {
+                warn!(
+                    "Ignoring GFF line in '{gff_file}' with fewer than 9 tab-separated fields: {trimmed}"
+                );
+                continue;
+            }
+            let contig = fields[0].to_string();
+            let start: u64 = fields[3].parse().unwrap_or_else(|_| {
+                panic!(
+                    "Failed to parse GFF start coordinate '{}' in {}",
+                    fields[3], gff_file
+                )
+            });
+            let end: u64 = fields[4].parse().unwrap_or_else(|_| {
+                panic!(
+                    "Failed to parse GFF end coordinate '{}' in {}",
+                    fields[4], gff_file
+                )
+            });
+            if start < 1 || end < start {
+                warn!(
+                    "Ignoring GFF line in '{gff_file}' with nonsensical coordinates ({start}, {end}): {trimmed}"
+                );
+                continue;
+            }
+            let name = parse_gff_id(fields[8]).unwrap_or_else(|| format!("{contig}_{start}_{end}"));
+            // GFF is 1-based and inclusive on both ends; convert to 0-based
+            // half-open [start, end).
+            genes.push(Gene {
+                name,
+                contig,
+                start: start - 1,
+                end,
+            });
+            num_read += 1;
+        }
+        info!("Read {num_read} features from GFF file {gff_file}");
+    }
+    genes
+}
+
+/// Extract a name for a feature from the GFF3 attributes column (column 9),
+/// preferring the `ID` attribute and falling back to `Name`.
+fn parse_gff_id(attributes: &str) -> Option<String> {
+    let mut name_attribute = None;
+    for attribute in attributes.split(';') {
+        let attribute = attribute.trim();
+        if let Some(value) = attribute.strip_prefix("ID=") {
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        } else if let Some(value) = attribute.strip_prefix("Name=") {
+            if !value.is_empty() && name_attribute.is_none() {
+                name_attribute = Some(value.to_string());
+            }
+        }
+    }
+    name_attribute
+}
+
+/// Per-gene accumulator used while iterating over a single contig's reads.
+struct GeneCalculator {
+    global_index: usize,
+    start: u64,
+    end: u64,
+    name: String,
+    num_mapped_reads: u64,
+    total_edit_distance: u64,
+    total_indels: u64,
+    sum_identity: f64,
+}
+
+pub fn gene_coverage<R: NamedBamReader, G: NamedBamReaderGenerator<R>, T: CoverageTaker>(
+    bam_readers: Vec<G>,
+    coverage_taker: &mut T,
+    coverage_estimators: &mut Vec<CoverageEstimator>,
+    print_zero_coverage_genes: bool,
+    flag_filters: &FlagFilter,
+    threads: u16,
+    genes: &[Gene],
+) -> Vec<ReadsMapped> {
+    let mut reads_mapped_vector = vec![];
+    for bam_generator in bam_readers {
+        let mut bam_generated = bam_generator.start();
+        bam_generated.set_threads(threads as usize);
+
+        let stoit_name = &(bam_generated.name().to_string());
+        coverage_taker.start_stoit(stoit_name);
+        let header = bam_generated.header().clone();
+        let target_names = header.target_names();
+
+        // Map contig name -> tid, then assign each relevant gene to its tid.
+        let mut contig_name_to_tid: HashMap<&[u8], u32> = HashMap::new();
+        for (tid, name) in target_names.iter().enumerate() {
+            contig_name_to_tid.insert(name, tid as u32);
+        }
+
+        let mut genes_by_tid: Vec<Vec<GeneCalculator>> =
+            (0..target_names.len()).map(|_| vec![]).collect();
+        let mut num_genes_not_in_bam = 0;
+        for gene in genes.iter() {
+            match contig_name_to_tid.get(gene.contig.as_bytes()) {
+                Some(&tid) => {
+                    let contig_length = header.target_len(tid).expect("Corrupt BAM file?");
+                    if gene.start >= contig_length {
+                        warn!(
+                            "Gene '{}' starts ({}) beyond the end of contig '{}' (length {}); skipping",
+                            gene.name, gene.start, gene.contig, contig_length
+                        );
+                        continue;
+                    }
+                    let end = std::cmp::min(gene.end, contig_length);
+                    genes_by_tid[tid as usize].push(GeneCalculator {
+                        global_index: 0, // assigned below
+                        start: gene.start,
+                        end,
+                        name: gene.name.clone(),
+                        num_mapped_reads: 0,
+                        total_edit_distance: 0,
+                        total_indels: 0,
+                        sum_identity: 0.0,
+                    });
+                }
+                None => num_genes_not_in_bam += 1,
+            }
+        }
+        if num_genes_not_in_bam > 0 {
+            warn!(
+                "{num_genes_not_in_bam} gene(s) were defined on contigs that are not \
+                 reference sequences in the BAM file for {stoit_name}"
+            );
+        }
+        // Sort genes on each contig by start position and assign a stable global
+        // index in (tid, start) order. This index is used as the entry order id
+        // so that output is emitted in a consistent order across samples.
+        let mut next_global_index = 0;
+        for tid_genes in genes_by_tid.iter_mut() {
+            tid_genes.sort_by_key(|g| (g.start, g.end));
+            for g in tid_genes.iter_mut() {
+                g.global_index = next_global_index;
+                next_global_index += 1;
+            }
+        }
+
+        let mut record: bam::record::Record = bam::record::Record::new();
+        let mut last_tid: i32 = -2; // no such tid in a real BAM file
+        let mut ups_and_downs: Vec<i32> = Vec::new();
+        let mut gene_sweep_lo: usize = 0;
+        let mut num_mapped_reads_total: u64 = 0;
+
+        loop {
+            match bam_generated.read(&mut record) {
+                None => break,
+                Some(Ok(())) => {}
+                Some(e) => panic!("Error reading BAM record: {:?}", e),
+            }
+
+            if !flag_filters.passes(&record) {
+                trace!("Skipping read based on flag filtering");
+                continue;
+            }
+            if record.is_unmapped() {
+                continue;
+            }
+            let tid = record.tid();
+            if tid != last_tid {
+                if tid < last_tid {
+                    error!("BAM file appears to be unsorted. Input BAM files must be sorted by reference (i.e. by samtools sort)");
+                    panic!("BAM file appears to be unsorted. Input BAM files must be sorted by reference (i.e. by samtools sort)");
+                }
+                if last_tid != -2 {
+                    process_previous_contig_genes(
+                        &mut genes_by_tid[last_tid as usize],
+                        &ups_and_downs,
+                        coverage_estimators,
+                        coverage_taker,
+                        print_zero_coverage_genes,
+                        &mut num_mapped_reads_total,
+                    );
+                }
+                // Emit zero coverage for genes on contigs between last_tid and
+                // tid that had no reads mapped.
+                if print_zero_coverage_genes {
+                    let from = if last_tid == -2 {
+                        0
+                    } else {
+                        last_tid as u32 + 1
+                    };
+                    for skipped_tid in from..(tid as u32) {
+                        print_zero_coverage_genes_for_contig(
+                            &genes_by_tid[skipped_tid as usize],
+                            coverage_estimators,
+                            coverage_taker,
+                        );
+                    }
+                }
+                ups_and_downs =
+                    vec![0; header.target_len(tid as u32).expect("Corrupt BAM file?") as usize];
+                gene_sweep_lo = 0;
+                last_tid = tid;
+            }
+
+            let is_primary = !record.is_supplementary() && !record.is_secondary();
+            if is_primary {
+                num_mapped_reads_total += 1;
+            }
+
+            // Walk the cigar, updating the coverage array and computing the
+            // reference span, aligned length and indels of this read.
+            let read_start: u64 = record.pos() as u64;
+            let mut cursor: usize = record.pos() as usize;
+            let mut aligned_len: u64 = 0;
+            let mut indels: u64 = 0;
+            for cig in record.cigar().iter() {
+                match cig {
+                    Cigar::Match(_) | Cigar::Diff(_) | Cigar::Equal(_) => {
+                        ups_and_downs[cursor] += 1;
+                        let final_pos = cursor + cig.len() as usize;
+                        if final_pos < ups_and_downs.len() {
+                            ups_and_downs[final_pos] -= 1;
+                        }
+                        cursor += cig.len() as usize;
+                        aligned_len += cig.len() as u64;
+                    }
+                    Cigar::Del(_) => {
+                        cursor += cig.len() as usize;
+                        indels += cig.len() as u64;
+                        aligned_len += cig.len() as u64;
+                    }
+                    Cigar::RefSkip(_) => {
+                        cursor += cig.len() as usize;
+                    }
+                    Cigar::Ins(_) => {
+                        indels += cig.len() as u64;
+                        aligned_len += cig.len() as u64;
+                    }
+                    Cigar::SoftClip(_) | Cigar::HardClip(_) | Cigar::Pad(_) => {}
+                }
+            }
+            let read_end: u64 = cursor as u64;
+
+            let edit = nm(&record);
+            let identity = if aligned_len > 0 {
+                (aligned_len as f64 - edit as f64) / aligned_len as f64
+            } else {
+                0.0
+            };
+
+            // Attribute this read to every gene on the contig that it overlaps.
+            // Reads arrive sorted by position, so genes that end before this
+            // read starts can never overlap a later read either.
+            let tid_genes = &mut genes_by_tid[tid as usize];
+            while gene_sweep_lo < tid_genes.len() && tid_genes[gene_sweep_lo].end <= read_start {
+                gene_sweep_lo += 1;
+            }
+            for gene in tid_genes[gene_sweep_lo..].iter_mut() {
+                if gene.start >= read_end {
+                    break;
+                }
+                if gene.end > read_start {
+                    gene.total_edit_distance += edit;
+                    gene.total_indels += indels;
+                    if is_primary {
+                        gene.num_mapped_reads += 1;
+                        if aligned_len > 0 {
+                            gene.sum_identity += identity;
+                        }
+                    }
+                }
+            }
+        }
+
+        // Process the final contig with reads, then any trailing contigs.
+        if last_tid != -2 {
+            process_previous_contig_genes(
+                &mut genes_by_tid[last_tid as usize],
+                &ups_and_downs,
+                coverage_estimators,
+                coverage_taker,
+                print_zero_coverage_genes,
+                &mut num_mapped_reads_total,
+            );
+        }
+        if print_zero_coverage_genes {
+            let from = if last_tid == -2 {
+                0
+            } else {
+                last_tid as u32 + 1
+            };
+            for skipped_tid in from..(target_names.len() as u32) {
+                print_zero_coverage_genes_for_contig(
+                    &genes_by_tid[skipped_tid as usize],
+                    coverage_estimators,
+                    coverage_taker,
+                );
+            }
+        }
+
+        let reads_mapped = ReadsMapped {
+            num_mapped_reads: num_mapped_reads_total,
+            num_reads: bam_generated.num_detected_primary_alignments(),
+        };
+        info!(
+            "In sample '{}', found {} reads mapped out of {} total ({:.*}%)",
+            stoit_name,
+            reads_mapped.num_mapped_reads,
+            reads_mapped.num_reads,
+            2,
+            (reads_mapped.num_mapped_reads * 100) as f64 / reads_mapped.num_reads as f64
+        );
+        reads_mapped_vector.push(reads_mapped);
+
+        if bam_generated.num_detected_primary_alignments() == 0 {
+            warn!(
+                "No primary alignments were observed for sample {stoit_name} \
+                 - perhaps something went wrong in the mapping?"
+            );
+        }
+
+        bam_generated.finish();
+    }
+    reads_mapped_vector
+}
+
+/// Compute and emit coverage statistics for all genes on a contig, given the
+/// contig's coverage (ups_and_downs) array.
+fn process_previous_contig_genes<T: CoverageTaker>(
+    tid_genes: &mut [GeneCalculator],
+    ups_and_downs: &[i32],
+    coverage_estimators: &mut [CoverageEstimator],
+    coverage_taker: &mut T,
+    print_zero_coverage_genes: bool,
+    _num_mapped_reads_total: &mut u64,
+) {
+    if tid_genes.is_empty() {
+        return;
+    }
+    // Cumulative coverage across the contig, so that a per-gene ups_and_downs
+    // array can be reconstructed for any sub-region.
+    let mut coverage: Vec<i32> = vec![0; ups_and_downs.len()];
+    let mut cumulative_sum: i32 = 0;
+    for (i, ud) in ups_and_downs.iter().enumerate() {
+        cumulative_sum += ud;
+        coverage[i] = cumulative_sum;
+    }
+
+    // Genes are sorted by start, which matches their global index order.
+    for gene in tid_genes.iter() {
+        let start = gene.start as usize;
+        let end = std::cmp::min(gene.end as usize, coverage.len());
+        if start >= end {
+            continue;
+        }
+        // Reconstruct a delta-encoded ups_and_downs array for the gene region
+        // whose running sum reproduces the contig coverage within the gene.
+        let gene_len = end - start;
+        let mut gene_ups_and_downs: Vec<i32> = vec![0; gene_len];
+        gene_ups_and_downs[0] = coverage[start];
+        for i in 1..gene_len {
+            gene_ups_and_downs[i] = coverage[start + i] - coverage[start + i - 1];
+        }
+
+        for estimator in coverage_estimators.iter_mut() {
+            estimator.setup();
+            estimator.add_contig(
+                &gene_ups_and_downs,
+                gene.num_mapped_reads,
+                gene.total_edit_distance - gene.total_indels,
+                gene.sum_identity,
+            );
+        }
+        let coverages: Vec<f32> = coverage_estimators
+            .iter_mut()
+            .map(|estimator| estimator.calculate_coverage(&[0]))
+            .collect();
+        let has_nonzero_coverage = coverages.iter().any(|&c| c > 0.0);
+
+        if print_zero_coverage_genes || has_nonzero_coverage {
+            coverage_taker.start_entry(gene.global_index, &gene.name);
+            for (coverage, estimator) in coverages.into_iter().zip(coverage_estimators.iter_mut()) {
+                estimator.print_coverage(coverage, coverage_taker);
+            }
+            coverage_taker.finish_entry();
+        }
+    }
+    for estimator in coverage_estimators.iter_mut() {
+        estimator.setup();
+    }
+}
+
+/// Emit zero coverage entries for all genes on a contig that had no reads.
+fn print_zero_coverage_genes_for_contig<T: CoverageTaker>(
+    tid_genes: &[GeneCalculator],
+    coverage_estimators: &[CoverageEstimator],
+    coverage_taker: &mut T,
+) {
+    for gene in tid_genes.iter() {
+        coverage_taker.start_entry(gene.global_index, &gene.name);
+        for estimator in coverage_estimators.iter() {
+            estimator.print_zero_coverage(coverage_taker, gene.end - gene.start);
+        }
+        coverage_taker.finish_entry();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use OutputWriter;
+
+    fn test_with_stream<R: NamedBamReader, G: NamedBamReaderGenerator<R>>(
+        expected: &str,
+        bam_readers: Vec<G>,
+        coverage_estimators: &mut Vec<CoverageEstimator>,
+        genes: &[Gene],
+        print_zero_coverage_genes: bool,
+    ) -> Vec<ReadsMapped> {
+        let tf: tempfile::NamedTempFile = tempfile::NamedTempFile::new().unwrap();
+        let t = tf.path().to_str().unwrap();
+
+        let flag_filters = FlagFilter {
+            include_improper_pairs: true,
+            include_secondary: false,
+            include_supplementary: false,
+        };
+        let reads_mapped_vec;
+        {
+            let mut coverage_taker =
+                CoverageTakerType::new_single_float_coverage_streaming_coverage_printer(
+                    OutputWriter::generate(Some(t)),
+                );
+            reads_mapped_vec = gene_coverage(
+                bam_readers,
+                &mut coverage_taker,
+                coverage_estimators,
+                print_zero_coverage_genes,
+                &flag_filters,
+                1,
+                genes,
+            );
+        }
+        assert_eq!(expected, std::fs::read_to_string(tf.path()).unwrap());
+        reads_mapped_vec
+    }
+
+    #[test]
+    fn test_parse_gff_id() {
+        assert_eq!(Some("gene1".to_string()), parse_gff_id("ID=gene1;Name=abc"));
+        assert_eq!(Some("abc".to_string()), parse_gff_id("Name=abc;locus=x"));
+        assert_eq!(None, parse_gff_id("locus=x"));
+    }
+
+    #[test]
+    fn test_read_gff_files() {
+        let genes = read_gff_files(&["tests/data/genes/2seqs.gff"]);
+        assert_eq!(
+            vec![
+                Gene {
+                    name: "gene1".to_string(),
+                    contig: "seq1".to_string(),
+                    start: 0,
+                    end: 1000,
+                },
+                Gene {
+                    name: "gene2".to_string(),
+                    contig: "seq1".to_string(),
+                    start: 199,
+                    end: 400,
+                },
+                Gene {
+                    name: "gene3".to_string(),
+                    contig: "seq2".to_string(),
+                    start: 0,
+                    end: 500,
+                },
+            ],
+            genes
+        );
+    }
+
+    #[test]
+    fn test_gene_spanning_whole_contig_matches_contig_coverage() {
+        // gene1 spans the whole of seq1, so its mean coverage should equal the
+        // whole-contig mean coverage of seq1 (1.2, per the contig-mode tests).
+        // gene3 spans the whole of seq2, which has no reads (0).
+        test_with_stream(
+            "2seqs.reads_for_seq1\tgene1\t1.2\n2seqs.reads_for_seq1\tgene3\t0\n",
+            generate_named_bam_readers_from_bam_files(vec!["tests/data/2seqs.reads_for_seq1.bam"]),
+            &mut vec![CoverageEstimator::new_estimator_mean(0.0, 0, false)],
+            &[
+                Gene {
+                    name: "gene1".to_string(),
+                    contig: "seq1".to_string(),
+                    start: 0,
+                    end: 1000,
+                },
+                Gene {
+                    name: "gene3".to_string(),
+                    contig: "seq2".to_string(),
+                    start: 0,
+                    end: 1000,
+                },
+            ],
+            true,
+        );
+    }
+
+    #[test]
+    fn test_no_zeros() {
+        test_with_stream(
+            "2seqs.reads_for_seq1\tgene1\t1.2\n",
+            generate_named_bam_readers_from_bam_files(vec!["tests/data/2seqs.reads_for_seq1.bam"]),
+            &mut vec![CoverageEstimator::new_estimator_mean(0.0, 0, false)],
+            &[
+                Gene {
+                    name: "gene1".to_string(),
+                    contig: "seq1".to_string(),
+                    start: 0,
+                    end: 1000,
+                },
+                Gene {
+                    name: "gene3".to_string(),
+                    contig: "seq2".to_string(),
+                    start: 0,
+                    end: 1000,
+                },
+            ],
+            false,
+        );
+    }
+
+    #[test]
+    fn test_count_estimator_per_gene() {
+        // Whole-contig read count for seq1 equals the number of reads mapped.
+        let reads_mapped = test_with_stream(
+            "2seqs.reads_for_seq1\tgene1\t12\n",
+            generate_named_bam_readers_from_bam_files(vec!["tests/data/2seqs.reads_for_seq1.bam"]),
+            &mut vec![CoverageEstimator::new_estimator_read_count()],
+            &[Gene {
+                name: "gene1".to_string(),
+                contig: "seq1".to_string(),
+                start: 0,
+                end: 1000,
+            }],
+            false,
+        );
+        assert_eq!(
+            vec![ReadsMapped {
+                num_mapped_reads: 12,
+                num_reads: 12,
+            }],
+            reads_mapped
+        );
+    }
+}

--- a/src/gene.rs
+++ b/src/gene.rs
@@ -134,6 +134,14 @@ pub fn gene_coverage<R: NamedBamReader, G: NamedBamReaderGenerator<R>, T: Covera
     threads: u16,
     genes: &[Gene],
 ) -> Vec<ReadsMapped> {
+    // Contig-end exclusion is meant to avoid mapping artifacts at the ends of
+    // contigs. In gene mode each gene is a sub-region of a contig, so applying
+    // the exclusion to gene boundaries would incorrectly trim every gene (and
+    // zero out any gene shorter than twice the exclusion). Disable it here.
+    for estimator in coverage_estimators.iter_mut() {
+        estimator.disable_contig_end_exclusion();
+    }
+
     let mut reads_mapped_vector = vec![];
     for bam_generator in bam_readers {
         let mut bam_generated = bam_generator.start();
@@ -313,6 +321,11 @@ pub fn gene_coverage<R: NamedBamReader, G: NamedBamReaderGenerator<R>, T: Covera
                     break;
                 }
                 if gene.end > read_start {
+                    // The read overlaps this gene. Edit distance and identity are
+                    // derived from the whole-read NM tag (which cannot be split
+                    // positionally between genes), so a read that straddles a gene
+                    // boundary contributes its whole-read statistics to each gene
+                    // it overlaps.
                     gene.total_edit_distance += edit;
                     gene.total_indels += indels;
                     if is_primary {
@@ -557,6 +570,26 @@ mod tests {
                 },
             ],
             true,
+        );
+    }
+
+    #[test]
+    fn test_contig_end_exclusion_disabled_in_gene_mode() {
+        // Even with a non-zero contig-end-exclusion, gene mode does not trim the
+        // ends of the gene, so a gene spanning the whole of seq1 reports the same
+        // value (1.2) as it does with no exclusion. Without disabling exclusion,
+        // 75 bases would be trimmed from each end.
+        test_with_stream(
+            "2seqs.reads_for_seq1\tgene1\t1.2\n",
+            generate_named_bam_readers_from_bam_files(vec!["tests/data/2seqs.reads_for_seq1.bam"]),
+            &mut vec![CoverageEstimator::new_estimator_mean(0.0, 75, false)],
+            &[Gene {
+                name: "gene1".to_string(),
+                contig: "seq1".to_string(),
+                start: 0,
+                end: 1000,
+            }],
+            false,
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@ pub mod coverage_printer;
 pub mod coverage_takers;
 pub mod external_command_checker;
 pub mod filter;
+pub mod gene;
 pub mod genome;
 pub mod genome_exclusion;
 pub mod genome_parsing;

--- a/src/mosdepth_genome_coverage_estimators.rs
+++ b/src/mosdepth_genome_coverage_estimators.rs
@@ -102,6 +102,34 @@ impl CoverageEstimator {
             CoverageEstimator::StrobealignAembEstimator { .. } => vec!["Strobealign aemb"],
         }
     }
+
+    /// Disable contig-end exclusion for this estimator by setting it to 0. Used
+    /// in gene (--gff) mode, where sub-regions of a contig are analysed and the
+    /// contig-end exclusion would otherwise incorrectly trim the ends of every
+    /// gene rather than just the ends of the contig.
+    pub fn disable_contig_end_exclusion(&mut self) {
+        match self {
+            CoverageEstimator::MeanGenomeCoverageEstimator {
+                contig_end_exclusion,
+                ..
+            }
+            | CoverageEstimator::TrimmedMeanGenomeCoverageEstimator {
+                contig_end_exclusion,
+                ..
+            }
+            | CoverageEstimator::PileupCountsGenomeCoverageEstimator {
+                contig_end_exclusion,
+                ..
+            }
+            | CoverageEstimator::VarianceGenomeCoverageEstimator {
+                contig_end_exclusion,
+                ..
+            } => {
+                *contig_end_exclusion = 0;
+            }
+            _ => {}
+        }
+    }
 }
 
 impl CoverageEstimator {

--- a/tests/data/genes/2seqs.gff
+++ b/tests/data/genes/2seqs.gff
@@ -1,0 +1,4 @@
+##gff-version 3
+seq1	CoverM	gene	1	1000	.	+	.	ID=gene1;Name=whole_seq1
+seq1	CoverM	gene	200	400	.	+	.	ID=gene2;Name=partial_seq1
+seq2	CoverM	gene	1	500	.	-	.	ID=gene3;Name=partial_seq2

--- a/tests/data/genes/7seqs.gff
+++ b/tests/data/genes/7seqs.gff
@@ -1,0 +1,6 @@
+##gff-version 3
+genome2~seq1	CoverM	gene	1	1000	.	+	.	ID=geneA;Name=whole_seq1
+genome5~seq2	CoverM	gene	1	1000	.	-	.	ID=geneB;Name=whole_seq2
+##FASTA
+>should_be_ignored
+ACGT

--- a/tests/test_cmdline.rs
+++ b/tests/test_cmdline.rs
@@ -590,6 +590,86 @@ genome6~random_sequence_length_11003	0",
     }
 
     #[test]
+    fn test_contig_gff_per_gene_output() {
+        // With --gff, `contig` reports per-gene coverage. Each gene here spans
+        // a whole contig, so the mean coverage matches the whole-contig value.
+        Assert::main_binary()
+            .with_args(&[
+                "contig",
+                "-b",
+                "tests/data/7seqs.reads_for_seq1_and_seq2.bam",
+                "--gff",
+                "tests/data/genes/7seqs.gff",
+                "--contig-end-exclusion",
+                "0",
+                "--output-format",
+                "dense",
+            ])
+            .succeeds()
+            .stdout()
+            .contains(
+                "Gene	7seqs.reads_for_seq1_and_seq2 Mean
+geneA	1.2
+geneB	1.2",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_contig_gff_sparse_length_and_count() {
+        Assert::main_binary()
+            .with_args(&[
+                "contig",
+                "-b",
+                "tests/data/7seqs.reads_for_seq1_and_seq2.bam",
+                "--gff",
+                "tests/data/genes/7seqs.gff",
+                "-m",
+                "length",
+                "count",
+                "--output-format",
+                "sparse",
+            ])
+            .succeeds()
+            .stdout()
+            .contains(
+                "Sample	Gene	Length	Read Count
+7seqs.reads_for_seq1_and_seq2	geneA	1000	12
+7seqs.reads_for_seq1_and_seq2	geneB	1000	12",
+            )
+            .unwrap();
+    }
+
+    #[test]
+    fn test_genome_gff_per_gene_output() {
+        // In `genome` mode, --gff also switches output to per-gene.
+        Assert::main_binary()
+            .with_args(&[
+                "genome",
+                "-m",
+                "mean",
+                "-b",
+                "tests/data/7seqs.reads_for_seq1_and_seq2.bam",
+                "-s",
+                "~",
+                "--gff",
+                "tests/data/genes/7seqs.gff",
+                "--contig-end-exclusion",
+                "0",
+                "--output-format",
+                "dense",
+            ])
+            .succeeds()
+            .stdout()
+            .contains(
+                "Gene	7seqs.reads_for_seq1_and_seq2 Mean
+geneA	1.2
+geneB	1.2",
+            )
+            .unwrap();
+    }
+
+    #[test]
     fn test_genome_dense_output_simple() {
         Assert::main_binary()
             .with_args(&[


### PR DESCRIPTION
## Summary

Adds a `--gff` option to `coverm contig` and `coverm genome`. When one or more GFF3 files are supplied, CoverM reports coverage statistics **per feature (gene)** rather than per-contig (contig mode) or per-genome (genome mode).

```bash
coverm contig -b mapping.bam --gff annotation.gff > per_gene_coverage.tsv
coverm genome -b mapping.bam -s '~' --gff annotation.gff -m mean
```

## How it works

- New `src/gene.rs` contains a small GFF3 parser (`read_gff_files`) and `gene_coverage()`, which mirrors `contig_coverage` but computes coverage over each gene's region on its parent contig.
- Each gene's per-base coverage is reconstructed from the contig's coverage array and fed through the existing `CoverageEstimator`s, so all coverage methods work (mean, trimmed_mean, covered_fraction, covered_bases, variance, length, count, reads_per_base, rpkm, tpm, anir, ...).
- Reads are attributed to genes by reference overlap (a position-sorted sweep), yielding per-gene read counts, edit distances and identities.
- Feature names come from the GFF `ID` attribute (falling back to `Name`, then `seqid_start_end`). The output uses a `Gene` header with one row per feature.
- The GFF seqid (column 1) must match a BAM reference sequence name. The trailing `##FASTA` section of a GFF3 file is ignored.

## Tests

- Unit tests in `src/gene.rs` for the GFF parser and gene coverage (a gene spanning a whole contig reproduces the whole-contig coverage; per-gene read counts).
- `assert_cli` integration tests in `tests/test_cmdline.rs` for both `contig --gff` and `genome --gff` (mean, length and count methods).
- Test GFF files added under `tests/data/genes/`.

All new tests pass; `cargo clippy --fix` and `cargo fmt` applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)